### PR TITLE
DM-4236

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -461,6 +461,12 @@ class ArgumentParser(argparse.ArgumentParser):
 
         obeyShowArgument(namespace.show, namespace.config, exit=False)
 
+        # No environment variable or --output or --rerun specified.
+        if self.requireOutput and namespace.output is None and namespace.rerun is None:
+            self.error("no output directory specified.\n"
+                       "An output directory must be specified with the --output or --rerun\n"
+                       "command-line arguments.\n")
+
         namespace.butler = dafPersist.Butler(
             root = namespace.input,
             calibRoot = namespace.calib,
@@ -495,12 +501,6 @@ class ArgumentParser(argparse.ArgumentParser):
         namespace.config.validate()
         namespace.config.freeze()
 
-        # No environment variable or --output or --rerun specified.
-        if self.requireOutput and namespace.output is None and namespace.rerun is None:
-            self.error("no output directory specified.\n"
-                       "An output directory must be specified with the --output or --rerun\n"
-                       "command-line arguments or the PIPE_OUTPUT_ROOT environment variable.\n")
-
         return namespace
 
     def _parseDirectories(self, namespace):
@@ -515,10 +515,8 @@ class ArgumentParser(argparse.ArgumentParser):
         # If an output directory is specified, process it and assign it to the namespace
         if namespace.rawOutput:
             namespace.output = _fixPath(DEFAULT_OUTPUT_NAME, namespace.rawOutput)
-        # This catches the case where the output was not specified, but _fixPath must still
-        # be run as there may be an environment variable set for the output
         else:
-            namespace.output = _fixPath(DEFAULT_OUTPUT_NAME, namespace.rawOutput)
+            namespace.output = None
 
         # This section processes the rerun argument, if rerun is specified as a colon separated
         # value, it will be parsed as an input and output. The input value will be overridden if

--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -38,7 +38,7 @@ import lsst.pex.logging as pexLog
 import lsst.daf.persistence as dafPersist
 
 __all__ = ["ArgumentParser", "ConfigFileAction", "ConfigValueAction", "DataIdContainer",
-    "DatasetArgument", "ConfigDatasetType"]
+           "DatasetArgument", "ConfigDatasetType", "InputOnlyArgumentParser"]
 
 DEFAULT_INPUT_NAME = "PIPE_INPUT_ROOT"
 DEFAULT_CALIB_NAME = "PIPE_CALIB_ROOT"
@@ -268,7 +268,6 @@ class ConfigDatasetType(DynamicDatasetType):
                 raise RuntimeError("Cannot find config parameter %r" % (self.name,))
         return value
 
-
 class ArgumentParser(argparse.ArgumentParser):
     """!An argument parser for pipeline tasks that is based on argparse.ArgumentParser
 
@@ -280,6 +279,8 @@ class ArgumentParser(argparse.ArgumentParser):
       before I do this checking. Constructing a butler is slow, so I only want do it once,
       after parsing the command line, so as to catch syntax errors quickly.
     """
+    requireOutput = True  # Require an output directory to be specified?
+
     def __init__(self, name, usage = "%(prog)s input [options]", **kwargs):
         """!Construct an ArgumentParser
 
@@ -494,6 +495,12 @@ class ArgumentParser(argparse.ArgumentParser):
         namespace.config.validate()
         namespace.config.freeze()
 
+        # No environment variable or --output or --rerun specified.
+        if self.requireOutput and namespace.output is None and namespace.rerun is None:
+            self.error("no output directory specified.\n"
+                       "An output directory must be specified with the --output or --rerun\n"
+                       "command-line arguments or the PIPE_OUTPUT_ROOT environment variable.\n")
+
         return namespace
 
     def _parseDirectories(self, namespace):
@@ -505,7 +512,6 @@ class ArgumentParser(argparse.ArgumentParser):
         mapperClass = dafPersist.Butler.getMapperClass(_fixPath(DEFAULT_INPUT_NAME,namespace.rawInput))
         namespace.calib = _fixPath(DEFAULT_CALIB_NAME,  namespace.rawCalib)
 
-        guessedRerun = False            # did we guess the rerun name?
         # If an output directory is specified, process it and assign it to the namespace
         if namespace.rawOutput:
             namespace.output = _fixPath(DEFAULT_OUTPUT_NAME, namespace.rawOutput)
@@ -513,8 +519,6 @@ class ArgumentParser(argparse.ArgumentParser):
         # be run as there may be an environment variable set for the output
         else:
             namespace.output = _fixPath(DEFAULT_OUTPUT_NAME, namespace.rawOutput)
-            if namespace.rawRerun is None:
-                guessedRerun = True
 
         # This section processes the rerun argument, if rerun is specified as a colon separated
         # value, it will be parsed as an input and output. The input value will be overridden if
@@ -522,24 +526,17 @@ class ArgumentParser(argparse.ArgumentParser):
         if namespace.rawRerun:
             if namespace.output:
                 self.error("Error: cannot specify both --output and --rerun")
-            namespace.rerun = tuple(os.path.join(namespace.input, "rerun", v)
-                                    for v in namespace.rawRerun.split(":"))
+            namespace.rerun = namespace.rawRerun.split(":")
+            rerunDir = [os.path.join(namespace.input, "rerun", dd) for dd in namespace.rerun]
             modifiedInput = False
-            if len(namespace.rerun) == 2:
-                namespace.input, namespace.output = namespace.rerun
+            if len(rerunDir) == 2:
+                namespace.input, namespace.output = rerunDir
                 modifiedInput = True
-            elif len(namespace.rerun) == 1:
-                if os.path.exists(namespace.rerun[0]):
-                    namespace.output = namespace.rerun[0]
-
-                    guessedInput = os.path.realpath(os.path.join(namespace.rerun[0], "_parent"))
-                    if guessedRerun and not os.path.exists(guessedInput):
-                        pass            # refuse the guesses
-                    else:
-                        namespace.input = guessedInput
-                        modifiedInput = True
-                else:
-                    namespace.output = namespace.rerun[0]
+            elif len(rerunDir) == 1:
+                namespace.output = rerunDir[0]
+                if os.path.exists(namespace.output):
+                    namespace.input = os.path.realpath(os.path.join(namespace.output, "_parent"))
+                    modifiedInput = True
             else:
                 self.error("Error: invalid argument for --rerun: %s" % namespace.rerun)
             if modifiedInput and dafPersist.Butler.getMapperClass(namespace.input) != mapperClass:
@@ -630,6 +627,12 @@ class ArgumentParser(argparse.ArgumentParser):
             if not arg.strip():
                 continue
             yield arg
+
+
+class InputOnlyArgumentParser(ArgumentParser):
+    """An ArgumentParser for pipeline tasks that don't write any output"""
+    requireOutput = False  # We're not going to write anything
+
 
 def getTaskDict(config, taskDict=None, baseName=""):
     """!Get a dictionary of task info for all subtasks in a config

--- a/tests/testArgumentParser.py
+++ b/tests/testArgumentParser.py
@@ -357,7 +357,7 @@ class ArgumentParserTestCase(unittest.TestCase):
         )
         self.assertEqual(namespace.input, os.path.abspath(DataPath))
         self.assertEqual(namespace.calib, None)
-        self.assertEqual(namespace.output, os.path.abspath(DataPath))
+        self.assertEqual(namespace.output, None)
 
     def testBareHelp(self):
         """Make sure bare help does not print an error message (ticket #3090)
@@ -491,16 +491,6 @@ class ArgumentParserTestCase(unittest.TestCase):
         self.assertEqual(args.input, DataPath)
         self.assertEqual(args.output, path)
         self.assertIsNone(args.rerun)
-
-        # Specified by environment variable
-        try:
-            os.environ["PIPE_OUTPUT_ROOT"] = path
-            args = parser.parse_args(config=self.config, args=[DataPath,])
-            self.assertEqual(args.input, DataPath)
-            self.assertEqual(args.output, path)
-            self.assertIsNone(args.rerun)
-        finally:
-            os.environ.pop("PIPE_OUTPUT_ROOT", None)
 
         # Specified by rerun
         args = parser.parse_args(config=self.config, args=[DataPath, "--rerun", "foo"])

--- a/tests/testArgumentParser.py
+++ b/tests/testArgumentParser.py
@@ -73,10 +73,9 @@ class SampleConfig(pexConfig.Config):
 class ArgumentParserTestCase(unittest.TestCase):
     """A test case for ArgumentParser."""
     def setUp(self):
-        self.ap = pipeBase.ArgumentParser(name="argumentParser")
+        self.ap = pipeBase.InputOnlyArgumentParser(name="argumentParser")
         self.ap.add_id_argument("--id", "raw", "help text")
         self.ap.add_id_argument("--otherId", "raw", "more help")
-        self.ap.requireOutput = False  # makes testing everything else easier
         self.config = SampleConfig()
         os.environ.pop("PIPE_INPUT_ROOT", None)
         os.environ.pop("PIPE_CALIB_ROOT", None)
@@ -379,8 +378,7 @@ class ArgumentParserTestCase(unittest.TestCase):
         for name in (None, "--foo"):
             for default in (None, "raw"):
                 argName = name if name is not None else "--id_dstype"
-                ap = pipeBase.ArgumentParser(name="argumentParser")
-                ap.requireOutput = False  # Allow simpler command-lines
+                ap = pipeBase.InputOnlyArgumentParser(name="argumentParser")
                 dsType = pipeBase.DatasetArgument(name=name, help=dsTypeHelp, default=default)
                 self.assertEqual(dsType.help, dsTypeHelp)
 
@@ -420,8 +418,7 @@ class ArgumentParserTestCase(unittest.TestCase):
         """Test DatasetArgument with a positional argument"""
         name = "foo"
         defaultDsTypeHelp = "dataset type to process from input data repository"
-        ap = pipeBase.ArgumentParser(name="argumentParser")
-        ap.requireOutput = False  # Allow simpler command-lines
+        ap = pipeBase.InputOnlyArgumentParser(name="argumentParser")
         dsType = pipeBase.DatasetArgument(name=name)
         self.assertEqual(dsType.help, defaultDsTypeHelp)
 
@@ -451,8 +448,7 @@ class ArgumentParserTestCase(unittest.TestCase):
         # use a different value as the default for the ConfigDatasetType
         # so the test can tell the difference
         name = "dsType"
-        ap = pipeBase.ArgumentParser(name="argumentParser")
-        ap.requireOutput = False  # Allow simpler command-line
+        ap = pipeBase.InputOnlyArgumentParser(name="argumentParser")
         dsType = pipeBase.ConfigDatasetType(name=name)
 
         ap.add_id_argument("--id", dsType, "help text")
@@ -468,7 +464,7 @@ class ArgumentParserTestCase(unittest.TestCase):
     def testConfigDatasetTypeNoFieldDefault(self):
         """Test ConfigDatasetType with a config field that has no default value"""
         name = "dsTypeNoDefault"
-        ap = pipeBase.ArgumentParser(name="argumentParser")
+        ap = pipeBase.InputOnlyArgumentParser(name="argumentParser")
         dsType = pipeBase.ConfigDatasetType(name=name)
 
         ap.add_id_argument("--id", dsType, "help text")


### PR DESCRIPTION
This prevents unintentionally writing in the top-level data repo
by leaving off "--output" or "--rerun" or $PIPE_OUTPUT_ROOT. If
none of these is set, we error out. This behavior can be disabled
by setting ArgumentParser.requireOutput = False.

In the process, cleaned up the rerun handling, so that the actual
rerun name is stored in namespace.rerun instead of a directory.

Added a test demonstrating various ways of specifying the output
directory.