### PR TITLE
TaskRunner: disable implicit threading when using multiprocessing

### DIFF
--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -25,6 +25,7 @@ import traceback
 import functools
 import contextlib
 
+from lsst.base import disableImplicitThreading
 import lsst.afw.table as afwTable
 
 from .task import Task, TaskError
@@ -181,6 +182,7 @@ class TaskRunner(object):
         """
         resultList = []
         if self.numProcesses > 1:
+            disableImplicitThreading()  # To prevent thread contention
             import multiprocessing
             self.prepareForMultiProcessing()
             pool = multiprocessing.Pool(processes=self.numProcesses, maxtasksperchild=1)


### PR DESCRIPTION
We have had trouble with low-level threaded packages (OpenBLAS, MKL)
implicitly using multiple threads if the user doesn't explicitly state
the number of desired threads, which increases contention when
parallelising at a higher level. We disable implicit threading when
using multiprocessing to protect the user. Our check can be disabled
by the user setting the environment variable LSST_ALLOW_IMPLICIT_THREADS
or by explicitly setting the number of threads using the environment
variables checked by the low-level threaded package.