### PR TITLE
Improve MDC handling in cmdLineTask (DM-10623)

### DIFF
--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -388,6 +388,9 @@ class TaskRunner(object):
                     traceback.print_exc(file=sys.stderr)
         task.writeMetadata(dataRef)
 
+        # remove MDC so it does not show up outside of task context
+        self.log.MDCRemove("LABEL")
+
         if self.doReturnResults:
             return Struct(
                 dataRef=dataRef,


### PR DESCRIPTION
Remove task-specific MDC from logger as soon as task completes to avoid
displaying that info outside of task context.