### PR TITLE
DM-11253: User documentation for command-line tasks (and Sphinx set up)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ doc/*.tag
 doc/html
 doc/doxygen.conf
 doc/xml
+doc/_build
+doc/py-api/
 python/lsst/pipe/base/version.py
 tests/.tests
 ups/*.cfgc

--- a/doc/_static/pipe_base/README.md
+++ b/doc/_static/pipe_base/README.md
@@ -1,0 +1,1 @@
+Use this directory for `pipe_base` static documentation resources (such as file downloads).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+import lsst.pipe.base
+from documenteer.sphinxconfig.stackconf import build_package_configs
+
+
+_g = globals()
+_g.update(build_package_configs(
+    project_name='pipe_base',
+    version=lsst.pipe.base.version.__version__))

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,0 +1,9 @@
+###############################
+pipe_base documentation preview
+###############################
+
+.. toctree::
+   :maxdepth: 1
+
+   pipe_base/index
+   lsst.pipe.base/index

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -134,9 +134,13 @@ Other named arguments are optional.
 
    The ``-L``/``--loglevel`` argument can appear multiple times.
 
+   For more information, see :ref:`command-line-task-logging-howto`.
+
 .. option:: --longlog
 
    **Enable the verbose logging format.**
+
+   See :ref:`command-line-task-logging-howto-longlog` for more information.
 
 .. option:: --debug
 

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -70,11 +70,15 @@ Other named arguments are optional.
 
    The ``-c``/``--config`` argument can appear multiple times.
 
+   See :ref:`command-line-task-config-howto-config` for more information.
+
 .. option:: -C <configfile>, --configfile <configfile>
 
    **Task configuration override file(s).**
 
    The ``-C``/``--configfile`` argument can appear multiple times.
+
+   See :ref:`command-line-task-config-howto-configfile` for more information.
 
 .. option:: --clobber-config
 

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -1,0 +1,349 @@
+.. _command-line-task-argument-reference:
+
+####################################
+Command-line task argument reference
+####################################
+
+This page describes the command-line arguments and environment variables common to command-line tasks.
+
+Signature and syntax
+====================
+
+The basic call signature of a command-line task is:
+
+.. code-block:: text
+
+   task.py REPOPATH [@file [@file2 ...]] [--output OUTPUTREPO | --rerun RERUN] [named arguments]
+
+See :ref:`command-line-argument-files` for details on ``@file`` syntax.
+
+For named arguments that take multiple values do not use a ``=`` after the argument name.
+For example, ``--configfile foo.py bar.py``, **not** ``--configfile=foo bar``.
+
+Status code
+===========
+
+A command-line task returns a status code of ``0`` if all data IDs were successfully processed.
+If the command-line task failed to process one or more data IDs, the status code is equal to the number of data IDs that failed.
+See also: :option:`--noExit`.
+
+Positional arguments
+====================
+
+.. option:: REPOPATH
+
+   **Input Butler data repository URI or path.**
+
+   The input Butler data repository is always the first argument to a command-line task.
+   This argument is required for all command-line task runs, except when printing help (:option:`--help`).
+
+   In general, this is a URI that depends on the Butler backend.
+   For example, ``swift://host/path`` for a Swift backend or ``file://path`` for a POSIX backend.
+
+   .. TODO DM-11671 Link to Butler docs on URIs.
+
+   For POSIX backends, this may also be an absolute file path or a path relative to the current working directory.
+   
+   If the :envvar:`PIPE_INPUT_ROOT` environment variable is set, then the ``REPOPATH`` is relative to that.
+   See :ref:`command-line-task-envvar-examples`.
+
+   For background, see :doc:`command-line-task-data-repo-howto`.
+
+   See also :option:`--rerun` argument to specify input and output reruns within this Butler repository.
+
+Named arguments
+===============
+
+An output data repository must be specified with either :option:`--output` **or** :option:`--rerun`.
+Other named arguments are optional.
+
+.. option:: --calib <calib_repo>
+
+   **Calibration data repository URI path.**
+
+   The path may be absolute, relative to the current working directory, or relative to :envvar:`PIPE_CALIB_ROOT` (when set).
+   See :ref:`command-line-task-envvar-examples`.
+
+.. option:: -c <name=val>, --config <name=val>
+
+   **Task configuration overrides.**
+
+   The ``-c``/``--config`` argument can appear multiple times.
+
+.. option:: -C <configfile>, --configfile <configfile>
+
+   **Task configuration override file(s).**
+
+   The ``-C``/``--configfile`` argument can appear multiple times.
+
+.. option:: --clobber-config
+
+   **Backup and overwrite existing config files.**
+
+   Normally a command line task checks existing config files in a Butler repository to ensure that the current configurations are consistent with previous pipeline executions.
+   This argument disables this check, which may be useful for development.
+
+   This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
+
+.. option:: --clobber-output
+
+   **Remove and re-create the output repository if it already exists.**
+
+   This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
+
+.. option:: --clobber-versions
+
+   **Backup and then overwrite existing package version provenance.**
+
+   Normally a command line task checks that the Science Pipelines package versions are the same as for previous executions that wrote to an output repository or rerun.
+   This argument disables this check, which may be useful for development.
+
+   This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
+
+.. option:: -h, --help
+
+   **Print help.**
+
+   The help is equivalent to this documentation page, describing command line arguments.
+   This help does not describe the command line task's specific functionality.
+
+.. option:: --id [[<dataid>] ...]
+
+   **Butler data IDs.**
+
+   Specify data IDs to process using data ID syntax.
+   For example, ``--id visit=12345 ccd=1,2^0,3``.
+
+   An ``--id`` argument without values indicates that **all** data available in the input repository will be processed.
+
+   For many-to-one processing tasks the ``--id`` argument specifies **output** data IDs, while :option:`--selectId` is used for **input** data IDs.
+
+   The ``--id`` argument can appear multiple times.
+
+.. option:: -L <level|component=level> [level|component=level...], --loglevel <level|component=level> [level|component=level...]
+
+   **Log level.**
+
+   Supported levels are: ``trace``, ``debug``, ``info``, ``warn``, ``error``, or ``fatal``.
+
+   Log levels can be set globally (``-L debug``) or for a specific named logger (``-L pipe.base=debug``).
+
+   Specify multiple arguments to control the global and named logging levels simultaneousy (``-L warn pipe.base=debug``).
+
+   The ``-L``/``--loglevel`` argument can appear multiple times.
+
+.. option:: --longlog
+
+   **Enable the verbose logging format.**
+
+.. option:: --debug
+
+   **Enable debugging mode.**
+
+   .. TODO DM-11675 cross-link to debug framework docs in lsst.base module.
+
+.. option:: --doraise
+
+   **Raise an exception on error.**
+
+   This mode causes the task to exit early if it encounters an error, rather than logging the error and continuing.
+
+.. option:: --no-backup-config
+
+   **Disable copying config to file~N backup.**
+
+.. option:: --no-versions
+
+   **Disable package version consistency validation.**
+
+   This mode permits data processing even if outputs exist in the output data repository or rerun from a different version of Science Pipelines packages.
+
+   This mode is useful for development should not be used in production processing.
+
+   See also :option:`--clobber-versions`.
+
+.. option:: --output <output_repo>
+
+   **Output data repository path.**
+
+   The output data repository will be created if it does not exist.
+
+   The path may be absolute, relative to the current working directory, or relative to :envvar:`PIPE_CALIB_ROOT` (when set).
+   See :ref:`command-line-task-envvar-examples`.
+
+   ``--output`` may not be used with the :option:`--rerun` argument.
+   See :option:`--rerun` for writing outputs to a rerun directory *inside* the input data repository.
+
+.. option:: -j <processes>, --processes <processes>
+
+   **Number of processes to use.**
+
+   When processes is larger than 1 the task uses the Python `multiprocessing` module to parallelize processing of multiple datasets across multiple processors.
+
+   See also :option:`--timeout`.
+
+.. option:: --profile <profile>
+
+   **Dump cProfile statistics to the named file.**
+
+   See the cProfile_ documentation.
+
+.. option:: --rerun <[input:]output>
+
+   **Specify output (and input) rerun (and optionally the input rerun as well).**
+
+   Reruns are named data repositories inside the :file:`rerun` directory of the root data repository (:option:`REPOPATH`).
+
+   ``--rerun output`` is equivalent to ``--output REPOPATH/rerun/output``.
+
+   An input rerun can also, optionally, be specified.
+   ``--rerun input:output`` sets the input repository path to ``ROOT/rerun/input`` the output repository path to ``REPOPATH/rerun/output``.
+
+   If an argument to `--rerun` starts with a `/`, it will be interpreted as an absolute path rather than as being relative to the root input data repository.
+
+   The arguments supplied to `--rerun` may refer to symbolic links to directories.
+   Data will be read or written from the links' targets.
+
+.. option:: --show <config|data|tasks|run>
+
+   **Print metadata without processing.**
+
+   Permitted values are:
+
+   - ``config``: show configuration state.
+
+   - ``data``: show data IDs resolved by the :option:`--id` argument
+
+   - ``tasks``: show sub-tasks run by the command-line task.
+
+   Multiple values can be shown at once.
+   For example, ``--show config data``.
+
+   Normally the command-line task will exit before processing any data.
+   If you want to *also* run the task after showing metadata, append the ``run`` value.
+   For example, ``--show config data run``.
+
+.. option:: --selectId
+
+   **Input data IDs for many-to-one tasks.**
+
+   For many-to-one processing tasks, such as coaddition, the :option:`--selectId` argument is used to specify input data IDs, while :option:`--id` is used to specify *output* data IDs.
+   The syntax for :option:`--selectId` is identical to that of :option:`--id`.
+
+.. option:: -t timeout, --timeout timeout
+
+   **Multiprocessing timeout (in seconds).***
+
+   See also :option:`-j`.
+
+.. option:: --noExit
+
+   **(Advanced) prevent the command-line task from exiting directly to the shell with a non-zero status code if there are one or more processing failures.**
+
+   If there are failures, by default, a command-line task exits to the directly shell with a status code equal to the number of data IDs that it failed to process.
+   This means that the command-line task does not return to the :ref:`run script <creating-a-command-line-task-run-script>` that originally called the `lsst.pipe.base.CmdLineTask.parseAndRun` method if there is an error.
+   Some command-line tasks (such as the MPI-enabled scripts in ``pipe_drivers``) need `lsst.pipe.base.CmdLineTask.parseAndRun` to always return to the run script.
+   In that case, use this ``--noExit`` argument.
+
+   When ``--noExit`` is used, the command-line task will not exit to the shell from `lsst.pipe.base.CmdLineTask.parseAndRun` if failures are encountered.
+   Instead, it will return normally to the run script that called `~lsst.pipe.base.CmdLineTask.parseAndRun`.
+   In this case, it is up to the run script to set an appropriate shell status code.
+
+   See also :option:`--doraise`.
+
+.. _command-line-argument-files:
+
+Argument files
+==============
+
+Arguments can be written to a plain text file and referenced with an ``@filepath`` command-line argument.
+The contents of argument files are identical to what you'd write on the command line, with these rules:
+
+- Text can be split across multiple lines.
+  For example, you can have one argument per line.
+
+- Do not use ``\`` as a continuation character.
+
+- Include comments with a ``#`` character.
+  Content on a line after the ``#`` character is ignored.
+
+- Blank lines and lines starting with ``#`` are ignored.
+
+You can mix argument files with other command-line arguments (including additional :option:`--id` and :option:`--config` arguments).
+
+You can include multiple ``@filepath`` references in the same command.
+
+Example
+-------
+
+For example, the file :file:`foo.txt` contains:
+
+.. code-block:: text
+
+   --id visit=54123^55523 raft=1,1^2,1 # data ID
+   --config someParam=someValue --configfile configOverrideFilePath
+
+You can then reference it with ``@foo.txt``, along with additional command-line arguments:
+
+.. code-block:: bash
+
+   task.py repo @foo.txt --config anotherParam=anotherValue --output outputPath
+
+.. _command-line-task-envvar:
+
+Environment variables
+=====================
+
+The :envvar:`PIPE_INPUT_ROOT`, :envvar:`PIPE_CALIB_ROOT`, and :envvar:`PIPE_OUTPUT_ROOT` environment variables let you more easily specify Butler data repositories.
+
+Each environment variable is used as a root directory for relative paths provided on the command line.
+If you set an absolute path on the command line, the environment variable is ignored.
+:ref:`see examples <command-line-task-envvar-examples>`.
+
+.. The default value for each of these environment variables is the current working directory.
+
+.. envvar:: PIPE_INPUT_ROOT
+
+   Root directory for the input Butler data repository argument, :option:`REPOPATH`.
+
+.. envvar:: PIPE_CALIB_ROOT
+
+   Root directory for the calibration Butler data repository argument (--calib).
+
+.. envvar:: PIPE_OUTPUT_ROOT
+
+   Root directory for the output Butler data repository argument (--output).
+
+.. _command-line-task-envvar-examples:
+
+Path environment variable examples
+----------------------------------
+
+These examples feature :envvar:`PIPE_INPUT_ROOT` to help specify the input data repository along with :option:`REPOPATH`, which is the first positional argument of any command.
+
+1. The data repository path is :file:`$PIPE_INPUT_ROOT/DATA` (or :file:`DATA` if :envvar:`PIPE_INPUT_ROOT` is undefined):
+   
+   .. code-block:: bash
+
+      processCcd.py DATA [...]
+
+2. The data repository path is :file:`$PIPE_INPUT_ROOT` (or current working directory if :envvar:`PIPE_INPUT_ROOT` is undefined):
+
+   .. code-block:: bash
+
+      processCcd.py . [...]
+
+3. The data repository path is an absolute path:
+   
+   .. code-block:: bash
+
+      processccd.py /DATA/a [...]
+
+   :envvar:`PIPE_INPUT_ROOT` is ignored in this case:
+
+The same behavior applies to the named arguments:
+
+- :option:`--calib` with :envvar:`PIPE_CALIB_ROOT`.
+- :option:`--output` with :envvar:`PIPE_OUTPUT_ROOT`.
+
+.. _cProfile: https://docs.python.org/library/profile.html

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -80,7 +80,7 @@ Other named arguments are optional.
 
    **Backup and overwrite existing config files.**
 
-   Normally a command line task checks existing config files in a Butler repository to ensure that the current configurations are consistent with previous pipeline executions.
+   Normally a command-line task checks existing config files in a Butler repository to ensure that the current configurations are consistent with previous pipeline executions.
    This argument disables this check, which may be useful for development.
 
    This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
@@ -95,7 +95,7 @@ Other named arguments are optional.
 
    **Backup and then overwrite existing package version provenance.**
 
-   Normally a command line task checks that the Science Pipelines package versions are the same as for previous executions that wrote to an output repository or rerun.
+   Normally a command-line task checks that the Science Pipelines package versions are the same as for previous executions that wrote to an output repository or rerun.
    This argument disables this check, which may be useful for development.
 
    This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
@@ -104,8 +104,8 @@ Other named arguments are optional.
 
    **Print help.**
 
-   The help is equivalent to this documentation page, describing command line arguments.
-   This help does not describe the command line task's specific functionality.
+   The help is equivalent to this documentation page, describing command-line arguments.
+   This help does not describe the command-line task's specific functionality.
 
 .. option:: --id [[<dataid>] ...]
 
@@ -164,7 +164,7 @@ Other named arguments are optional.
 
 .. option:: --output <output_repo>
 
-   **Output data repository path.**
+   **Output data repository URI or path.**
 
    The output data repository will be created if it does not exist.
 
@@ -172,7 +172,8 @@ Other named arguments are optional.
    See :ref:`command-line-task-envvar-examples`.
 
    ``--output`` may not be used with the :option:`--rerun` argument.
-   See :option:`--rerun` for writing outputs to a rerun directory *inside* the input data repository.
+
+   See :doc:`command-line-task-data-repo-howto` for background.
 
 .. option:: -j <processes>, --processes <processes>
 
@@ -190,19 +191,20 @@ Other named arguments are optional.
 
 .. option:: --rerun <[input:]output>
 
-   **Specify output (and input) rerun (and optionally the input rerun as well).**
+   **Specify output rerun (and optionally the input rerun as well).**
 
-   Reruns are named data repositories inside the :file:`rerun` directory of the root data repository (:option:`REPOPATH`).
-
+   Reruns are data repositories relative to the root repository, :option:`REPOPATH`.
    ``--rerun output`` is equivalent to ``--output REPOPATH/rerun/output``.
 
    An input rerun can also, optionally, be specified.
-   ``--rerun input:output`` sets the input repository path to ``ROOT/rerun/input`` the output repository path to ``REPOPATH/rerun/output``.
+   ``--rerun input:output`` sets the input repository path to ``REPOPATH/rerun/input`` the output repository path to ``REPOPATH/rerun/output``.
 
    If an argument to `--rerun` starts with a `/`, it will be interpreted as an absolute path rather than as being relative to the root input data repository.
 
    The arguments supplied to `--rerun` may refer to symbolic links to directories.
    Data will be read or written from the links' targets.
+
+   See :doc:`command-line-task-data-repo-howto` for more information.
 
 .. option:: --show <config|data|tasks|run>
 

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -195,6 +195,8 @@ Other named arguments are optional.
 
    See also :option:`--timeout`.
 
+   See :ref:`command-line-task-parallel-howto` for more information.
+
 .. option:: --profile <profile>
 
    **Dump cProfile statistics to the named file.**

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -113,12 +113,14 @@ Other named arguments are optional.
 
    Specify data IDs to process using data ID syntax.
    For example, ``--id visit=12345 ccd=1,2^0,3``.
+   For more information, see :ref:`command-line-task-dataid-howto`.
 
-   An ``--id`` argument without values indicates that **all** data available in the input repository will be processed.
+   An ``--id`` argument without values indicates that **all** data available in the input repository will be processed (see :ref:`command-line-task-dataid-howto-wildcard`).
 
    For many-to-one processing tasks the ``--id`` argument specifies **output** data IDs, while :option:`--selectId` is used for **input** data IDs.
 
    The ``--id`` argument can appear multiple times.
+   See :ref:`command-line-task-dataid-howto-multi-arg`.
 
 .. option:: -L <level|component=level> [level|component=level...], --loglevel <level|component=level> [level|component=level...]
 
@@ -231,6 +233,8 @@ Other named arguments are optional.
 
    For many-to-one processing tasks, such as coaddition, the :option:`--selectId` argument is used to specify input data IDs, while :option:`--id` is used to specify *output* data IDs.
    The syntax for :option:`--selectId` is identical to that of :option:`--id`.
+
+   For more information about dataId selection syntax, see :ref:`command-line-task-dataid-howto`.
 
 .. option:: -t timeout, --timeout timeout
 

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -85,6 +85,8 @@ Other named arguments are optional.
 
    This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
 
+   See :ref:`command-line-task-prov-howto-config` for more information.
+
 .. option:: --clobber-output
 
    **Remove and re-create the output repository if it already exists.**
@@ -99,6 +101,8 @@ Other named arguments are optional.
    This argument disables this check, which may be useful for development.
 
    This argument is safe with :option:`-j` multiprocessing, but not necessarily with other forms of parallel execution.
+
+   See :ref:`command-line-task-prov-howto-versions` for more information.
 
 .. option:: -h, --help
 
@@ -167,6 +171,8 @@ Other named arguments are optional.
    This mode is useful for development should not be used in production processing.
 
    See also :option:`--clobber-versions`.
+
+   See :ref:`command-line-task-prov-howto-versions` for more information.
 
 .. option:: --output <output_repo>
 

--- a/doc/lsst.pipe.base/command-line-task-config-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-config-howto.rst
@@ -1,0 +1,151 @@
+.. _command-line-task-config-howto:
+
+##############################
+Configuring command-line tasks
+##############################
+
+:ref:`Command-line tasks <using-command-line-tasks>` are highly configurable.
+This page describes how to review configurations with :option:`--show config <--show>`,  and change configurations on the command line with :option:`--config` or :option:`--configfile`.
+
+One special category of configuration is subtask retargeting.
+Retargeting uses concepts discussed on this page, but with additional considerations described in :doc:`command-line-task-retargeting-howto`.
+
+.. _command-line-task-config-howto-show:
+
+How to show a command-line task's current configuration
+=======================================================
+
+The :option:`--show config <--show>` argument allows you to review the current configuration details for command-line tasks. 
+
+.. tip::
+
+   :option:`--show config <--show>` puts the command-line task in a dry-run mode where no data processed.
+   Once you're done reviewing configurations, remove the :option:`--show` argument from the command-line task invocation to actually process data.
+
+   Alternatively, add ``run`` to the :option:`--show` argument to show configurations *and* process data: :option:`--show config run <--show>`.
+
+.. _command-line-task-config-howto-show-all:
+
+Viewing all configurations
+--------------------------
+
+Use :option:`--show config <--show>` to see all current configurations for a command-line task.
+For example:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --show config
+
+Note that both the input and output Butler data repositories repository must be set to show camera-specific task configuration defaults.
+Instead of an :option:`--output` argument you can specify a :option:`--rerun`, see :doc:`command-line-task-data-repo-howto`.
+
+.. _command-line-task-config-howto-show-subset:
+
+Viewing a subset of configurations
+----------------------------------
+
+To filter the :option:`--show config <--show>` output, include a search term with wildcard matching (``*``) characters.
+For example, this will show any configuration that includes the string ``calibration``:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --show config="*calibration*"
+
+.. _command-line-task-config-howto-config:
+
+How to set configurations with command-line arguments
+=====================================================
+
+Command-line tasks can be configured through a combination of two mechanisms: arguments on the command line (:option:`--config`) or through configuration files (:option:`--configfile`).
+In general, simple configurations can be made through the command line, while complex configurations and :ref:`subtask retargeting <command-line-task-retargeting-howto>` must done through configuration files (see :ref:`command-line-task-config-howto-configfile`).
+
+To change a configuration value on the command line, pass that configuration name and value to the :option:`--config` argument.
+For example, to set a configuration named ``skyMap.projection`` to a value ``"TAN"``:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --config skyMap.projection="TAN"
+
+You can provide multiple :option:`--config` arguments on the same command line or set multiple configurations with a single :option:`--config` argument:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --config config1="value1" config2="value2"
+
+Only simple configuration values can be set through :option:`--config` arguments, such as:
+
+- **String values**. For example: ``--config configName="value"``.
+- **Scalar numbers**. For example: ``--config configName=2.5``.
+- **Lists of integers**. For example: ``--config intList=2,4,-87``.
+- **List of floating point numbers**. For example: ``--config floatList=3.14,-5.6e7``.
+- **Boolean values**. For example: ``--config configName=True configName2=False``.
+
+Specific types of configurations you **cannot** perform with the :option:`--config` argument are:
+
+- You cannot :doc:`retarget a subtask <command-line-task-retargeting-howto>` specified by a `lsst.pex.config.ConfigurableField` (which is the most common case).
+- For items in registries, you can only specify values for the active (current) item.
+  See :ref:`command-line-task-retargeting-howto-registry-active-config`.
+- You cannot specify values for lists of strings.
+- You cannot specify a subset of a list.
+  You must specify all values at once.
+
+For these more complex configuration types you must use configuration files, which are evaluated as Python code.
+
+.. _command-line-task-config-howto-configfile:
+
+How to use configuration files
+==============================
+
+You can also provide configurations to a command-line task through a *configuration file*.
+In fact, configuration files are Python modules; anything you can do in Python you can do in a configuration file.
+
+Configuration files give you full access to the configuration API, allowing you to import and :doc:`retarget subtasks <command-line-task-retargeting-howto>`, and set configurations with complex types.
+These configurations can only be done through configuration files, not through command-line arguments.
+
+Use a configuration file by providing its file path through a :option:`-C`/:option:`--configfile` argument:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --configfile taskConfig.py
+
+Multiple configuration files can be provided through the same :option:`--configfile` argument and the :option:`--configfile` argument itself can be repeated.
+
+In a configuration file, configurations are attributes of a ``config`` object.
+If on the command line you set a configuration with a ``--config skyMap.projection="TAN"`` argument, in a configuration file the equivalent statement is:
+
+.. code-block:: python
+
+   config.skyMap.projection = "TAN"
+
+``config`` is the root configuration object for the command-line task.
+Settings for the command-line task itself are attributes of ``config``.
+In that example, ``config.skyMap`` is a subtask and ``projection`` is a configuration of that ``skyMap`` subtask.
+
+.. _command-line-task-config-howto-obs:
+
+About configuration defaults and camera configuration override files
+====================================================================
+
+Command-line task configurations are a combination of configurations you provide and defaults from the observatory package and the task itself.
+
+When a command-line task is run, it loads two camera-specific configuration files, if found: one for the observatory package, and one for a specific camera defined in that observatory package.
+For an example observatory package named ``obs_package``, these configuration override files are, in order:
+
+- ``obs_package/config/taskName.py`` (overrides for an observatory package in general).
+- ``obs_package/config/cameraName/taskName.py`` (overrides for a specific camera, named “\ ``cameraName``\ ”).
+
+The ``taskName`` is the command-line task, such as ``processCcd`` for :command:``processCcd.py`` (this is the `lsst.pipe.base.CmdLineTask._DefaultName` class variable).
+
+Here are two examples:
+
+- :file:`obs_lsstSim/config/makeCoaddTempExp.py`: specifies which version of the image selector task to use for co-adding LSST simulated images using the ``obs_lsstSim`` observatory package.
+- :file:`obs_subaru/config/hsc/isr.py``: provides overrides for the instrument signature removal (aka detrending) task for the ``hsc`` camera (Hyper Suprime-Cam) in the ``obs_subaru`` observatory package.
+
+Overall, the priority order for setting task configurations is configurations is (highest priority first):
+
+1. User-provided :option:`--config` and :option:`--configfile` arguments (computed left-to-right).
+2. Camera specific configuration override file in an observatory package.
+3. General configuration override file in an observatory package.
+4. Task defaults.
+
+.. TODO DM-11687 include an example with --show history to see configuration histories.

--- a/doc/lsst.pipe.base/command-line-task-data-repo-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-data-repo-howto.rst
@@ -1,0 +1,185 @@
+.. TODO DM-11685 Add opinionated suggestions on how to use reruns versus output repositories.
+
+.. _command-line-task-data-repo-howto:
+
+#################################################################
+Using Butler data repositories and reruns with command-line tasks
+#################################################################
+
+:ref:`Command-line tasks <using-command-line-tasks>` use Butler data repositories for reading and writing data.
+This page describes two ways for specifying data repositories on the command line:
+
+1. Specify input and output repository URIs (or *file paths* for POSIX-backed Butler data repositories) with the :option:`REPOPATH` and :option:`--output` command-line arguments.
+   Read about this in :ref:`command-line-task-data-repo-using-output`.
+
+2. Use reruns, which are output data repositories relative to a single root repository, with the :option:`REPOPATH` and :option:`--rerun` arguments.
+   Read about this pattern in :ref:`command-line-task-data-repo-using-reruns`.
+
+.. _command-line-task-data-repo-using-uris:
+
+About repository paths and URIs
+===============================
+
+.. TODO DM-11671 Move this section to the Butler user guide.
+
+Butler data repositories can be hosted on a variety of backends, from a local POSIX directory to a more specialized data store like Swift.
+All Butler backends are functionally equivalent from a command line user's perspective.
+In each case, you specify a data repository with its URI.
+
+For a POSIX filesystem backend, you can specify a path to the repository directory through:
+
+- A relative path.
+- An absolute path.
+- A URI prefixed with ``file://``.
+
+Other backends always require a URI.
+For example, a URI like ``swift://host/path`` points to a Butler repository backed by the Swift object store.
+
+In the how-to topics below, URIs or POSIX paths can be used as needed for the :file:`inputrepo` (:option:`REPOPATH`) and :file:`outputrepo` (:option:`--output`) command-line arguments.
+
+.. _command-line-task-data-repo-using-output:
+
+Using input and output repositories
+===================================
+
+How to create a new output repository
+-------------------------------------
+
+To have a command-line task read data from a :file:`inputrepo` repository and write to a :file:`outputrepo` output repository, set the :option:`REPOPATH` and :option:`--output` arguments like this:
+
+.. code-block:: text
+
+   task.py inputrepo --output outputrepo ...
+
+The :file:`outputrepo` directory will be created if it does not already exist.
+
+.. _command-line-task-data-repo-using-output-chaining:
+
+How to chain output repositories
+--------------------------------
+
+The output repository for one task can become the input repository for the next command-line task.
+For example:
+
+.. code-block:: text
+
+   task2.py outputrepo --output outputrepo2 ...
+
+Because Butler data repositories are *chained*, the output repository (here, :file:`outputrepo2`) provides access to all the datasets from the input repositories (here: :file:`inputrepo`, :file:`outputrepo`, and :file:`outputrepo2` itself).
+
+How to re-use output repositories
+---------------------------------
+
+An output repository can be the same as the input repository:
+
+.. code-block:: text
+
+   task3.py outputrepo2 --output outputrepo2 ...
+
+This pattern is useful for reducing the number of repositories.
+Packing outputs from multiple tasks into one output repository does reduce your flexibility to run a task several times with different configurations and compare outputs, though.
+
+You can also run the same task multiple times with the same output repository.
+Be aware that the Science Pipelines will help you maintain the integrity of the processed data's provenance.
+If you change a task's configuration and re-run the task into the same output repository, an error "Config does not match existing task config" will be shown.
+See :doc:`command-line-task-prov-howto`.
+
+How to use repository path environment variables
+------------------------------------------------
+
+The :envvar:`PIPE_INPUT_ROOT` and :envvar:`PIPE_OUTPUT_ROOT` environment variables can help you specify data repository paths more succinctly.
+When set, the :option:`REPOPATH` argument path is treated as relative to :envvar:`PIPE_INPUT_ROOT` and the :option:`--output` path is relative to :envvar:`PIPE_OUTPUT_ROOT`.
+
+These environment variables are optional.
+Then they aren't set in your shell, the :option:`REPOPATH` and :option:`--output` arguments alone specify the paths or URIs to Butler data repositories.
+
+See :ref:`command-line-task-envvar` for details.
+
+.. _command-line-task-data-repo-using-reruns:
+
+Using reruns to organize outputs in a single data repository
+============================================================
+
+.. TODO DM-11685 Add example strategies for organizing reruns.
+.. E.g. https://github.com/lsst/pipe_base/pull/37/files#r135243612
+
+An alternative way to organize output data repositories is with **reruns** (:option:`--rerun` command-line argument)
+Reruns are a convention for repositories that are located relative to single root data repository.
+If the root repository's URI is :file:`file://REPOPATH`, a rerun called ``my_rerun`` automatically has a full URI of:
+
+.. code-block:: text
+
+   file://REPOPATH/rerun/my_rerun
+
+In practice, you don't need to know the full URIs of individual reruns.
+Instead, you just need to know the URI of the root repository and the names of individual reruns.
+This makes reruns especially convenient in practice.
+
+How to create a rerun
+---------------------
+
+To use input data from a :file:`DATA` Butler repository and write outputs to a rerun called ``A``, set a command-line task's :option:`REPOPATH` and :option:`--rerun` like this:
+
+.. code-block:: bash
+
+   task1.py DATA --rerun A ...
+
+.. tip::
+
+   Once you've created an output rerun with one command-line task you can re-use it as the output repository for subsequent command-line task runs (see :ref:`command-line-task-data-repo-using-rerun-reuse`)
+
+   Alternatively, you can chain new reruns together with each processing step (see the next section).
+
+   For perspective on when to create a new rerun, or reuse an existing one, see :ref:`command-line-task-data-repo-using-rerun-strategy`.
+
+.. _command-line-task-data-repo-using-rerun-chaining:
+
+How to use one rerun as input to another (chaining)
+---------------------------------------------------
+
+To use data written to rerun ``A`` as inputs but have results written to a new rerun ``B``, use the :option:`--rerun` argument's ``input:output`` syntax, like this:
+
+.. code-block:: bash
+
+   task2.py DATA --rerun A:B ...
+
+This syntax automatically *chains* rerun ``B`` to rerun ``A``, just like Butler repository chaining in general (see :ref:`command-line-task-data-repo-using-output-chaining`).
+For example if rerun ``B`` is later used as an **input** rerun, it will provide access to datasets in rerun ``B``, rerun ``A``, and the root repository :file:`DATA` itself.
+
+.. _command-line-task-data-repo-using-rerun-reuse:
+
+How to write outputs to an existing rerun
+-----------------------------------------
+
+Tasks can write to an existing rerun.
+For example, if rerun ``B`` was already created you can write additional outputs to it:
+
+.. code-block:: bash
+
+   task3.py DATA --rerun B ...
+
+Because reruns are chained, the Butler will start looking for datasets in this rerun ``B``, then in the chained ``A`` rerun, all the way to the root data repository (:file:`DATA`).
+This chaining is transparent to you.
+You *don't* need to know which repository in the chain a given input dataset comes from.
+All you need to know is the root data repository and the terminal rerun's name.
+
+When reusing a rerun for multiple runs of the *same* command-line task, be aware of configuration consistency checks.
+See :doc:`command-line-task-prov-howto` for more information.
+
+.. _command-line-task-data-repo-using-rerun-strategy:
+
+When to create a new rerun
+--------------------------
+
+.. TODO DM-11685 Add opinionated suggestions on to organize reruns
+
+When using multiple command-line tasks to process data, you have the option of re-using the same rerun or creating a new chained rerun for each successive task.
+How you use reruns is up to you.
+
+Reruns are useful for creating processing checkpoints (hence their name).
+You can run the same task with different configurations, writing the output of each to a different rerun.
+By analyzing and comparing equivalent datasets in each rerun, you can make informed decisions about task configuration.
+
+Without using separate reruns, tasks will report an error if the same task is processing data with different configurations than before.
+These checks are in place to ensure that the provenance of data processing is traceable.
+See :doc:`command-line-task-prov-howto` for more information.

--- a/doc/lsst.pipe.base/command-line-task-dataid-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-dataid-howto.rst
@@ -1,0 +1,223 @@
+.. TODO DM-11671 cross-link to Butler and dataset documentation on data IDs
+
+.. _command-line-task-dataid-howto:
+
+###########################################
+Specifying data IDs with command-line tasks
+###########################################
+
+:ref:`Command-line tasks <using-command-line-tasks>` consume data and output new data products.
+You can tell a command-line task exactly what data to process by passing data IDs to the task's :option:`--id` argument.
+The task combines the data IDs you provide with the dataset types it expects to retrieve specific datasets for processing with the Butler.
+
+This page describes how to use the :option:`--id` argument to select data for command-line task processing.
+This documentation also applies to the :option:`--selectId` argument for many-to-one processing tasks.
+
+.. _command-line-task-dataid-howto-about-dataid-keys:
+
+About data ID keys
+==================
+
+.. TODO Link to dataset documentation to show these data ID keys in practice.
+
+Individual data IDs are composed of a set of keys and their values.
+The set of keys that are included in a data ID depend on the dataset type and even the observatory package.
+The important categories of data IDs are for exposures (generally, individual observations from an observatory) and coadds.
+
+Exposure data IDs are typically described by ``visit`` (unique observation number), ``ccd`` (sensor in camera), ``filter``, ``field``, ``dateObs``, among other keys.
+For example, the data ID keys and values for a Hyper Suprime-Cam exposure look like:
+
+.. code-block:: text
+
+   visit=903334 ccd=23 filter=HSC-R field=STRIPE82L pointing=533 dateObs=2013-06-17 taiObs=2016-06-17
+
+.. note::
+
+   This is a *fully-qualified* data ID.
+   In most cases you can uniquely identify a dataset on the command line by specifying a subset of these keys (like ``visit`` and ``ccd``).
+   Learn more about this in :ref:`command-line-task-dataid-howto-kv`.
+
+Datasets related to coadds are typically described by the coadd's tract and patch location, and filter.
+For example:
+
+.. code-block:: text
+
+   filter=HSC-R tract=0 patch=1,1
+
+The following sections describe how to find and select data IDs on the command line.
+
+.. _command-line-task-dataid-howto-show-data:
+
+How to find data IDs available to a command-line task
+=====================================================
+
+Given an input Butler data repository at :option:`REPOPATH`, and optionally :ref:`a rerun <command-line-task-data-repo-howto>` given a :option:`--rerun` argument, you can discover available data and their data IDs with the :option:`--show data <--show>` command-line task argument:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id --show data ...
+
+Each printed line is a data ID, composed of keys and values, for separate datasets.
+For example:
+
+.. code-block:: text
+
+   id dataRef.dataId = {'taiObs': '2013-06-17', 'pointing': 533, 'visit': 903334, 'dateObs': '2013-06-17', 'filter': 'HSC-R', 'field': 'STRIPE82L', 'ccd': 23, 'expTime': 30.0}
+
+.. tip::
+
+   Use the :option:`--show data <--show>` argument in conjunction with the :option:`--id` argument (more on this below) to confirm what data is being selected.
+   The task won't process data in this mode (unless you add a ``run`` value to the :option:`--show` argument, as in :option:`--show data run <--show>`).
+
+.. _command-line-task-dataid-howto-wildcard:
+
+How to specify all available data IDs
+=====================================
+
+To process all data available in a Butler data repository (for a task's dataset type), use the :option:`--id` argument without specifying any data ID keys and values:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id
+
+This mode acts like a wildcard glob of all available data IDs.
+You'll see wildcard :option:`--id` arguments used for small Butler repositories, like tutorial examples.
+
+For most realistic Butler data repositories, though, you will want to specify a subset of the available data IDs to process.
+This is described next.
+
+.. tip::
+
+   In general, command-line tasks do not need to work on single datasets.
+   If the :option:`--id` argument resolves to multiple datasets, the command-line task will process each dataset as if you ran that command-line task multiple times on each dataset alone.
+
+.. _command-line-task-dataid-howto-kv:
+
+How to filter by data ID key-value pairs on the command line
+============================================================
+
+When you pass a data ID key-value pair to :option:`--id`, the command-line task selects datasets for processing that have matching data ID key-value pairs.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id filter=HSC-R
+
+In this example, only datasets with data IDs that have a ``filter`` key equal to ``HSC-R`` are selected.
+
+You include multiple data ID key-value pairs in the same :option:`--id` argument.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id filter=HSC-R tract=0
+
+Now only datasets with data IDs that have both a ``filter`` key equal to ``HSR-R`` *and* a ``tract`` key equal to ``0`` are selected.
+
+.. tip::
+
+   You generally never need to supply all keys for a data ID to :option:`--id`.
+   Instead, think of :option:`--id` as a database query: you only need to include the necessary data ID key-value pairs to pare down the full collection of datasets in a Butler data repository to the ones you want to process with a command-line task.
+
+.. _command-line-task-dataid-howto-or-syntax:
+
+How to specify multiple discrete values (“^” syntax)
+====================================================
+
+To include multiple discrete values for a single data ID key, use the ``^`` operator:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id ccd=1^3^5
+
+In this example, datasets are selected that have a ``ccd`` data ID key with values of 1, 3, or 5.
+
+.. _command-line-task-dataid-howto-range-syntax:
+
+How to specify ranges and strides (“..” and “:” syntax)
+=======================================================
+
+For data ID key values that are ordered and continuous sequences (such as visit numbers or CCD identifiers), you can use ``start..end`` syntax to select the whole range from the given start to the end (inclusive) points.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id ccd=1..5
+
+In this example, datasets with ``ccd`` data ID keys with values 1, 2, 3, 4, or 5 are selected.
+
+.. important::
+
+   Unlike ranges in Python, both the start and end values are inclusive to the selected range.
+
+.. important::
+
+   You cannot stride over gaps in sequences.
+   For example, if ccd ``2`` doesn't exist, you cannot specify the stride ``--id ccd=1..5``.
+   Instead, you'll need to use other syntax (multiple `option:`--id` arguments, ``:`` strides, or ``^`` contatenations) to deal with the gap.
+
+You can also *stride* over a range with ``:stride`` syntax.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id ccd=1..5:2
+
+This example selects datasets that have ``ccd`` data ID keys with values 1, 3, or 5.
+
+Multiple strides can also be concatenated with ``^`` syntax.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id ccd=1..5^10..15
+
+This example selects datasets that have ``ccd`` data ID keys with values of 1 though 5 and 10 through 15.
+
+.. _command-line-task-dataid-howto-crossproduct:
+
+About multiple values with multiple keys
+========================================
+
+If you specify multiple values for multiple data ID keys in a :option:`--id` argument, the cross product of all the key-value pairs is computed.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id filter=HSC-R visit=100..102 ccd=1^2
+
+From that :option:`--id` argument, this set of data ID key-value pairs is computed:
+
+.. code-block:: text
+
+   filter=HSR-R visit=100 ccd=1
+   filter=HSR-R visit=101 ccd=1
+   filter=HSR-R visit=102 ccd=1
+   filter=HSR-R visit=100 ccd=2
+   filter=HSR-R visit=101 ccd=2
+   filter=HSR-R visit=102 ccd=2
+
+.. _command-line-task-dataid-howto-multi-arg:
+
+How to use multiple :option:`--id` arguments
+============================================
+
+You may use multiple :option:`--id` arguments in the same command-line task invocation.
+For each :option:`--id` argument a list of datasets is independently selected, and then these dataset lists are concatenated.
+This feature is useful for selecting multiple datasets with more flexibility than the previously mentioned syntax affords.
+
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id filter=HSC-R ccd=1^2 --id filter=HSC-I ccd=5
+
+From those :option:`--id` arguments, these data ID key-value pairs are computed:
+
+.. code-block:: text
+
+   filter=HSC-R ccd=1
+   filter=HSC-R ccd=2
+   filter=HSC-I ccd=5
+
+The first two data IDs are produced by the first :option:`--id` argument and the third data ID is produced by the second :option:`--id` argument.

--- a/doc/lsst.pipe.base/command-line-task-logging-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-logging-howto.rst
@@ -1,0 +1,83 @@
+.. _command-line-task-logging-howto:
+
+###############################
+Logging with command-line tasks
+###############################
+
+:ref:`Command-line tasks <using-command-line-tasks>` generate logging output that can be used to monitor and help debug processing.
+This page describes some features and patterns for customizing and taking advantage of the logging output.
+
+.. _command-line-task-logging-howto-level:
+
+How to set logging level in general
+===================================
+
+In general, you can change the logging level with the :option:`--loglevel` (:option:`-L`) argument.
+For example, to reduce the verbosity of logging to only including warnings and more severe messages:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id --loglevel warn
+
+.. _command-line-task-logging-howto-logger-level:
+
+How to set the logging level for a specific logger
+==================================================
+
+To change the logging level for a specific logger, use the ``--loglevel logger=level`` syntax.
+For example, to enable debug-level logging for the ``processCcd.calibrate`` logger:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --id --loglevel processCcd.calibrate=debug
+
+You may provide multiple values to multiple values to :option:`--loglevel` to specify the level of multiple loggers, along with the global level.
+For example, to set the default log level to ``warn``, but enable ``info``-level logging for the ``processCcd.calibrate`` logger:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --id --loglevel warn processCcd.calibrate=info
+
+Equivalently, you can also specify multiple :option:`--loglevel` arguments:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --id --loglevel warn --loglevel processCcd.calibrate=info
+
+.. _command-line-task-logging-howto-longlog:
+
+Using the verbose logging format
+================================
+
+Set the :option:`--longlog` argument to get a verbose logging message.
+This format is especially useful for parallel data processing since the data IDs of the data being processed are included in each message to let you later separate the processing streams.
+An example message looks like:
+
+.. code-block:: text
+
+   INFO  2017-07-18T04:40:14.014 processCcd.calibrate ({'taiObs': '2013-11-02', 'pointing': 671, 'visit': 904014, 'dateObs': '2013-11-02', 'filter': 'HSC-I', 'field': 'STRIPE82L', 'ccd': 1, 'expTime': 30.0})(calibrate.py:545)- Photometric zero-point: 30.674190
+
+Fields are:
+
+- Log level.
+- Timestamp.
+- Logger name (the Python namespace, without the root ``lsst`` package).
+- Fully-qualified data ID.
+- Code module and source line.
+- Log message.
+
+.. _command-line-task-logging-howto-tee:
+
+How to log to the console and a file simultaneously
+===================================================
+
+Logging output from command-line tasks goes to standard output (stdout) and standard error (sterr) console streams.
+There isn't a built-in facility to stream logging output to the console and a file simultaneously.
+But you can use the common program :command:`tee` to simultaneous send logging output to both the console and a file.
+
+In a :command:`bash` or :command:`csh`-like shell, simply append a command-like task invocation with ``|& tee filename.log``.
+For example:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id |& tee filename.log

--- a/doc/lsst.pipe.base/command-line-task-parallel-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-parallel-howto.rst
@@ -1,0 +1,102 @@
+.. _command-line-task-parallel-howto:
+
+###########################################
+Parallel processing with command-line tasks
+###########################################
+
+:ref:`Command-line tasks <using-command-line-tasks>` can operate in parallel.
+Generally if a command-line task is run against several :ref:`data IDs <command-line-task-dataid-howto>`, each data ID can be processed in parallel.
+Command-line tasks use two different categories of parallel processing: single-node parallel processing (:option:`-j`) and distributed processing (with the ``pipe_drivers`` and ``ctrl_pool`` packages).
+This page describes how to use these parallel processing features.
+
+.. _command-line-task-parallel-howto-multiprocessing:
+
+How to enable single-node parallel processing
+=============================================
+
+Command-line tasks can process multiple data IDs in parallel across multiple CPUs of one machine if you provide a :option:`-j`/:option:`--processes` argument with a value greater than ``1``.
+For example, to spread processing across up to eight CPUs:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id -j 8 ...
+
+When operating with :option:`-j`, command-line tasks have a default per-process timeout of 720 hours.
+You can change this timeout via the :option:`--timeout` command-line argument.
+
+Log messages from each process are combined into the same console output stream.
+To discern logging statements from each process use the :option:`--longlog` argument to enable a verbose logging format that includes the data ID being processed.
+See :ref:`command-line-task-logging-howto-longlog` for more information.
+
+.. note::
+
+   Internally, :option:`-j`-type multiprocessing is implemented with the `multiprocessing` module in the Python standard library.
+
+   If a task does not support :option:`-j` parallel processing it will report a non-fatal warning:
+
+   .. code-block:: text
+
+      This task does not support multiprocessing; using one process
+
+   Specifying ``-j 1`` disables multiprocessing altogether (the default).
+
+.. _command-line-task-parallel-howto-distributed:
+
+How to enable distributed processing
+====================================
+
+Command-line tasks implemented in the ``pipe_drivers`` package can distribute processing across multiple nodes using MPI or batch submission to clusters (PBS or SLURM).
+The ``--batchType`` argument controls which processing system is used.
+``--batchType None`` disables multiprocessing with "driver" tasks.
+See the ``pipe_drivers`` documentation for more information.
+
+.. _command-line-task-parallel-howto-threading:
+
+How to control threading while parallel processing
+==================================================
+
+LSST Science Pipelines uses low-level math libraries that support threading.
+OpenBLAS_ and MKL_ default to using the same number of threads as CPUs present on the machine.
+When parallel processing at a higher level (using :option:`-j`, for example), threading in these libraries can result in a **net decrease in performance** because of thread contention.
+
+When running with :option:`-j` multiprocessing or via ``ctrl_pool``, command-line tasks check if low-level libraries are using their default threading behavior (same number of threads as CPUs).
+If so, the task will automatically disable multi-threading in these libraries.
+The command-line task also sends a warning when it does so:
+
+.. code-block:: text
+
+   WARNING: You are using OpenBLAS with multiple threads (16), but have not specified the number of threads using one of the OpenBLAS environment variables: OPENBLAS_NUM_THREADS, GOTO_NUM_THREADS, OMP_NUM_THREADS. This may indicate that you are unintentionally using multiple threads, which may cause problems. WE HAVE THEREFORE DISABLED OpenBLAS THREADING. If you know what you are doing and want threads enabled implicitly, set the environment variable LSST_ALLOW_IMPLICIT_THREADS.
+
+The recommended resolution to this warning is to specifically limit the number of threads used by OpenBLAS_ and MKL_.
+For example, in a :command:`bash` or similar shell set the ``OMP_NUM_THREADS`` environment variable:
+
+.. code-block:: bash
+
+   export OMP_NUM_THREADS=1
+
+.. note::
+
+   ``OMP_NUM_THREADS`` is recognized by both OpenBLAS_ and MKL_ so it is likely the only environment variable that needs to be set.
+
+   Alternatively, specific environment variables used by the libraries are:
+
+   - OpenBLAS: ``OPENBLAS_NUM_THREADS``, ``GOTO_NUM_THREADS``, and ``OMP_NUM_THREADS``.
+   - MLK: ``MKL_NUM_THREADS``, ``MKL_DOMAIN_NUM_THREADS``, ``OMP_NUM_THREADS``.
+
+If necessary, you may bypass a command-line task's control over threading in low-level math libraries by setting the ``LSST_ALLOW_IMPLICIT_THREADS`` environment variable.
+For example, in a :command:`bash` shell:
+
+.. code-block:: bash
+
+   export LSST_ALLOW_IMPLICIT_THREADS=1
+
+.. seealso::
+
+   These functions in `lsst.base` implement threading detection and control:
+
+   - `lsst.base.disableImplicitThreading`
+   - `lsst.base.getNumThreads`
+   - `lsst.base.setNumThreads`
+
+.. _OpenBLAS: http://www.openblas.net
+.. _MKL: http://www.openblas.net

--- a/doc/lsst.pipe.base/command-line-task-prov-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-prov-howto.rst
@@ -1,0 +1,76 @@
+.. _command-line-task-prov-howto:
+
+####################################################
+Working with provenance checks in command-line tasks
+####################################################
+
+:ref:`Command-line tasks <using-command-line-tasks>` include provenance checks to ensure datasets in a Butler repository are processed with consistent software versions and task configurations.
+This page provides background on what these provenance checks are, and how they can be overridden when running command-line tasks.
+
+.. _command-line-task-prov-howto-config:
+
+How to override configuration checks with the :option:`--clobber-config` argument
+=================================================================================
+
+When a command-line task outputs datasets it also persists the task's configuration to the Butler output repository.
+If the same command-line task is later run on the same Butler output repository, that task will ensure that the configuration is identical to the earlier run's configuration.
+If the current and previous task configurations are different, the command-line task will abort with an error:
+
+.. code-block:: text
+
+   Config does not match existing task config <name> on disk; tasks configurations must be consistent within the same output repo (override with --clobber-config)
+
+This check ensures that datasets in a Butler repository are uniformly processed.
+
+You may often experiment with different task configurations while prototyping a pipeline.
+The best way to avoid configuration conflicts is to run each experimental command-line task execution with a different output :ref:`rerun <command-line-task-data-repo-using-reruns>`.
+Creating separate reruns gives you the ability to later analyze how dataset differ with task configuration.
+See :ref:`command-line-task-data-repo-using-reruns` for details on how to do this.
+
+If you cannot create a new output rerun, and must re-use an existing data repository, you can overwrite (clobber) existing task configuration metadata with the current configurations to bypass the consistency check.
+Use the :option:`--clobber-config` argument to do so:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id --clobber-config ...
+
+.. warning::
+
+   :option:`--clobber-config` is subject to race conditions because it is modifying a file in the Butler repository.
+   :option:`--clobber-config` is safe to use with :option:`-j`/:option:`--processes` but not other forms of parallel processing.
+
+.. _command-line-task-prov-howto-versions:
+
+How to override software version checks with :option:`--no-versions` or :option:`--clobber-versions`
+====================================================================================================
+
+If a command-line task attempts to write datasets to a Butler output repository that already contains data processed with a different version of LSST Science Pipelines software, a "``Version mismatch``" error is triggered.
+This error should be heeded in most cases because datasets created by one version of the LSST Science Pipelines may not be compatible with another version.
+Developers may need to suppress this error during testing, though.
+There are two ways to do this: :option:`--no-versions`, and :option:`--clobber-versions`.
+
+Use :option:`--no-versions` to simply bypass version checking:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id --no-versions ...
+
+This argument is thread-safe and likely ideal for developers.
+
+An alternative method of bypassing software version provenance checks is the :option:`--clobber-versions` argument:
+
+.. code-block:: bash
+
+   task.py REPOPATH --output output --id --clobber-versions ...
+
+Like :option:`--clobber-config`, the :option:`--clobber-versions` argument replaces software version provenance information in the Butler data repository with current version information.
+This argument is useful if you wish to continue using an existing Butler data repository with a different version of the Science Pipelines, and are confident that there are not dataset incompatibilities.
+
+.. warning::
+
+   :option:`--clobber-versions` is subject to race conditions because it is modifying a file in the Butler repository.
+   :option:`--clobber-versions` is safe to use with :option:`-j`/:option:`--processes` but not other forms of parallel processing.
+
+.. seealso::
+
+   For details about how software version information is retrieved, see the `lsst.base.packages` documentation.

--- a/doc/lsst.pipe.base/command-line-task-retargeting-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-retargeting-howto.rst
@@ -1,0 +1,135 @@
+.. FIXME DM-11558 re-address this topic with DM-11558 to improve accuracy.
+.. See also questions in https://github.com/lsst/pipe_base/pull/37/files#diff-7be10bd28b721e80b8ced2d45c26d119
+
+.. _command-line-task-retargeting-howto:
+
+##########################################
+Retargeting subtasks of command-line tasks
+##########################################
+
+Subtasks of :ref:`command-line tasks <using-command-line-tasks>` are dynamically retargetable, meaning that you can configure which task class is run by a parent class.
+Subtask retargeting is a special case of :ref:`command-line task configuration <command-line-task-config-howto>`.
+
+A common use of retargeting is to change a default subtask for a camera-specific one.
+For example:
+
+- `lsst.obs.subaru.isr.SuprimeCamIsrTask`: a version of instrument signature removal (ISR or detrending) for Suprime-Cam and Hyper Suprime-Cam.
+- `lsst.obs.sdss.selectSdssImages.SelectSdssImagesTask`: an version of the task that selects images for co-addition of SDSS stripe 82 images.
+
+How you retarget a subtask and override its config parameters depends on whether the task is specified as an `lsst.pex.config.ConfigurableField` (the most common case) or as an `lsst.pex.config.RegistryField`.
+Both scenarios are described on this page.
+
+.. _command-line-task-retargeting-howto-show-subtasks:
+
+Viewing configured subtasks
+===========================
+
+To see what subtasks are currently configured to run with a command-line task, use the :option:`--show tasks <--show>` argument (this runs the command-line task in a dry-run mode that shows tasks but does not process data).
+For example:
+
+.. code-block:: bash
+
+   processCcd.py REPOPATH --output output --show tasks
+
+An example of the printed output is:
+
+.. code-block:: text
+
+   sub-tasks:
+   calibrate: lsst.pipe.tasks.calibrate.CalibrateTask
+   calibrate.applyApCorr: lsst.meas.base.applyApCorr.ApplyApCorrTask
+   calibrate.astromRefObjLoader: lsst.meas.algorithms.loadIndexedReferenceObjects.LoadIndexedReferenceObjectsTask
+   calibrate.astrometry: lsst.meas.astrom.astrometry.AstrometryTask
+   calibrate.astrometry.matcher: lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask
+   ...
+
+This subtask hierarchy is interpreted as follows:
+
+- The ``calibrate`` subtask of the command-line task (:command:`processCcd.py`) is configured to use `lsst.pipe.tasks.calibrate.CalibrateTask`.
+- ``calibrate`` (again, implemented by `~lsst.pipe.tasks.calibrate.CalibrateTask`) has a subtask named ``astrometry``, which is currently configured to use the `lsst.meas.astrom.astrometry.AstrometryTask` task.
+- ``calibrate.astrometry`` has a subtask named ``matcher``, which is implemented by `~lsst.meas.astrom.matchOptimisticB.matchOptimisticBContinued.MatchOptimisticBTask`.
+
+Note that if the ``calibrate.astrometry`` task is retargeted to a different task class, the subtask of ``calibrate.astrometry`` *may* change (for example, ``calibrate.astrometry.matcher`` may no longer exist).
+
+.. _command-line-task-retargeting-howto-configurablefield:
+
+How to retarget a subtask configured as a ConfigurableField with a configuration file
+=====================================================================================
+
+To retarget a subtask specified as an `lsst.pex.config.ConfigurableField`, you must use a configuration file (specified by :option:`--configfile`, see :ref:`command-line-task-config-howto-configfile`).
+Inside a configuration file, retargeting is done in two steps:
+
+1. Import the Task class you intend to use.
+2. Assign that class to to the subtask configuration using the `~lsst.pex.config.ConfigurableField.retarget` method.
+
+For example, to retarget the subtask named ``configurableSubtask`` with a class ``FooTask``, this configuration file should contain:
+
+.. code-block:: python
+
+   from ... import FooTask
+   config.configurableSubtask.retarget(FooTask)
+
+.. TODO make this a realistic example.
+
+Once a subtask is retargeted, you can configure it as normal by setting attributes to configuration parameters.
+For example:
+
+.. code-block:: python
+
+   config.configurableSubtask.subtaskParam1 = newValue
+
+.. warning::
+
+   When you retarget a task specified by an `lsst.pex.config.ConfigurableField` you lose all :ref:`configuration overrides <command-line-task-config-howto-obs>` for both the old and new task.
+   This limitation is not shared by `lsst.pex.config.RegistryField`.
+
+.. _command-line-task-retargeting-howto-registry-configfile:
+
+How to retarget a subtask configured as a RegistryField with a configuration file
+=================================================================================
+
+To retarget a subtask specified as an `lsst.pex.config.RegistryField`, set the field's `~lsst.pex.config.RegistryField.name` attribute in a configuration file (using :option:`--configfile`).
+Here is an example that assumes a task ``FooTask`` is defined in module :file:`.../foo.py` and registered using name ``foo``:
+
+.. code-block:: python
+
+   import .../foo.py
+   config.registrySubtask.name = "foo"
+
+Besides retargeting the registry subtask, there are two ways to configure parameters for tasks in a registry:
+
+- :ref:`Set parameters for the active subtask <command-line-task-retargeting-howto-registry-active-config>` using the `~lsst.pex.config.RegistryField`\ ’s `~lsst.pex.config.RegistryField.active` attribute.
+- :ref:`Set parameters for any registered task <command-line-task-retargeting-howto-registry-config>` using dictionary notation and the subtask's registered name.
+
+These configuration methods are described next.
+
+.. _command-line-task-retargeting-howto-registry-active-config:
+
+Configure the active subtask configured as a RegistryField
+----------------------------------------------------------
+
+You may configure the retargeted subtask in a configuration file by setting the subtask configuration's `~lsst.pex.config.RegistryField.active` attribute.
+For example:
+
+.. code-block:: python
+
+   config.registrySubtask.active.subtaskParam1 = newValue
+
+These configurations can also be specified directly on the command line as a :option:`--config` argument.
+For example:
+
+.. code-block:: bash
+
+   --config registrySubtask.active.subtaskParam1=newValue
+
+.. _command-line-task-retargeting-howto-registry-config:
+
+Configure any subtask in a registry
+-----------------------------------
+
+Alternatively, you can then configure parameters for any subtask in the registry using key-value access.
+For example:
+
+.. code-block:: python
+
+   config.registrySubtask["foo"].subtaskParam1 = newValue

--- a/doc/lsst.pipe.base/creating-a-command-line-task.rst
+++ b/doc/lsst.pipe.base/creating-a-command-line-task.rst
@@ -1,0 +1,254 @@
+.. TODO DM-11674 This topic should be edited into the modernized topic-based documentation style.
+.. See comments: https://github.com/lsst/pipe_base/pull/37/files#diff-afb70dbd7b37e15ec4ff6c41991730e8
+
+.. _creating-a-command-line-task:
+
+############################
+Creating a command-line task
+############################
+
+This document describes how to write a command-line task, which is the LSST version of a complete data processing pipeline.
+To create a command-line task you will benefit from some background:
+
+- Read :doc:`task-framework-overview` to get a basic idea of what tasks are and what classes are used to implement them.
+- Read :doc:`creating-a-task`.
+  A command-line task is an enhanced version of a regular task.
+  Thus all the considerations for writing a normal task also apply to writing a command-line task, and these will not be repeated in this manual.
+- Acquire a basic understanding of data repositories and how to use the butler to read and write data (to be written; for now read existing tasks to see how it is done).
+
+.. _creating-a-command-line-task-intro:
+
+Introduction
+============
+
+A command-line task is an enhanced version of a regular task (see :ref:`creating-a-task`).
+Regular tasks are only intended to be used as relatively self-contained stages in data processing pipelines, whereas command-line tasks can also be used as complete pipelines.
+As such, command-line tasks include :ref:`run scripts <creating-a-command-line-task-run-script>` that run them as pipelines.
+
+Command-line tasks have the following key attributes, in addition to the attributes for regular tasks:
+
+- They are subclasses of `lsst.pipe.base.CmdLineTask`, whereas regular tasks are subclasses of `lsst.pipe.base.Task`.
+- They have an associated :ref:`run script <creating-a-command-line-task-run-script>` to run them from the command-line as pipelines (this is common, but not required, for regular tasks).
+- They have a ``run`` method which performs the full pipeline data processing.
+- By default the ``run`` method takes exactly one argument: a data reference for the item of data to be processed.
+  Variations are possible, but require that you provide a :ref:`custom argument parser <creating-a-command-line-task-custom-argparse>` and often a :ref:`custom task runner <creating-a-command-line-task-custom-task-runner>`.
+- When run from the command line, most command-line tasks save the configuration used and the metadata generated.
+  See :ref:`creating-a-command-line-task-persisting-config-and-metadata` for more information.
+- They have an additional :ref:`class variable <creating-a-task-class-variables>`, ``RunnerClass``, that specifies a "task runner" for the task.
+  The task runner takes a parsed command and runs the task.
+  The default task runner will work for any script whose `run` method accepts a single data reference, such as ``ExampleCmdLineTask``.
+  If your task's `run` method needs something else then you will have to provide a :ref:`custom task runner <creating-a-command-line-task-custom-task-runner>`.
+- They have an additional :ref:`class variable <creating-a-task-class-variables>` ``canMultiprocess``, which defaults to `True`.
+  If your task runner cannot run your task with multiprocessing then set it `False`.
+  Note: multiprocessing only affects how the task runner calls the top-level task; thus it is ignored when a task is used as a subtask.
+
+.. _creating-a-command-line-task-run-script:
+
+Run Script
+==========
+
+A command-line task can be run as a pipeline via run script.
+This is usually a trivial script which merely calls the task's ``parseAndRun`` method. ``parseAndRun`` does the following:
+
+- Parses the command line, which includes determining the :ref:`configuration <creating-a-task-configuration>` for the task and which data items to process.
+- Constructs the task.
+- Calls the task's ``run`` method once for each data item to process.
+
+``examples/exampleCmdLineTask.py``, the runner script for ``ExampleCmdLineTask``, is typical:
+
+.. code-block:: python
+
+   #!/usr/bin/env python2
+   from lsst.pipe.tasks.exampleCmdLineTask import ExampleCmdLineTask
+   ExampleCmdLineTask.parseAndRun()
+
+For most command-line tasks you should put the run script into your package's :file:`bin/` directory, so that it is on your ``$PATH`` when you setup your package with eups.
+We did not want the run script for ``ExampleCmdLineTask`` to be quite so accessible, so we placed it in the :file:`examples/` directory instead of :file:`bin/`.
+
+Remember to make your run script executable using :command:`chmod +x`.
+
+.. _creating-a-command-line-task-data-io:
+
+Reading and Writing Data
+========================
+
+The :ref:`run method <creating-a-command-line-task-intro>` typically receives a single data reference, as mentioned above.
+It read and writes data using this data reference (or the underlying butler, if necessary).
+
+.. _creating-a-command-line-task-dataset-types:
+
+Adding Dataset Types
+--------------------
+
+Every time you write a task that writes a new kind of data (a new "dataset type") you must tell the butler about it.
+Similarly, if you write a new task for which you want to save configuration and metadata (which is the case for most tasks that process data), you have to tell the butler about it.
+
+To add a dataset, edit the mapper configuration file for each observatory package on whose data the task can be run.
+If the task is of general interest (wanted for most or all observatory packages) then this process of updating all the mapper configuration files can be time consuming.
+
+There are plans to change how mappers are configured.
+But as of this writing, mapper configuration files are contained in the policy directory of the observatory package.
+For instance the configuration for the lsstSim mapper is defined in ``obs_lsstSim/policy/LsstSimMapper.paf``.
+
+.. _creating-a-command-line-task-persisting-config-and-metadata:
+
+Persisting Config and Metadata
+==============================
+
+Normally when you run a task you want the configuration for the task and the metadata generated by the task to be saved to the data repository.
+By default, this is done automatically, using dataset types:
+
+- ``_DefaultName_config`` for the configuration
+- ``_DefaultName_metadata`` for the metadata
+
+where ``_DefaultName`` is replaced with the value of the task's ``_DefaultName``, see :ref:`class variable <creating-a-task-class-variables>`.
+
+Whether you use these default dataset types or :ref:`customize the dataset types <creating-a-command-line-task-custom-config-and-metadata-types>`, you will have to :ref:`add dataset types <creating-a-command-line-task-dataset-types>` for the configuration and metadata.
+
+.. _creating-a-command-line-task-custom-config-and-metadata-types:
+
+Customizing Config and Metadata Dataset Types
+---------------------------------------------
+
+Occasionally the default dataset types for configuration and metadata are not sufficient.
+For instance in the case of the `pipe.tasks.makeSkyMap.MakeSkyMapTask` and various co-addition tasks, the co-add type must be part of the config and metadata dataset type name.
+To customize the dataset type of a task's config or metadata, define task methods ``_getConfigName`` and ``_getMetadataName`` to return the desired names.
+
+.. _creating-a-command-line-task-prevent-saving-config:
+
+Prevent Saving Config and Metadata
+----------------------------------
+
+For some tasks you may wish to not save config and metadata at all.
+This is appropriate for tasks that simply report information without saving data.
+To disable saving configuration and metadata, define task methods ``_getConfigName`` and ``_getMetadataName`` methods to return `None`.
+
+.. _creating-a-command-line-task-custom-argparse:
+
+Custom Argument Parser
+======================
+
+The default `lsst.pipe.base.argumentParser.ArgumentParser`-type returned by `CmdLineTask._makeArgumentParser` assumes that your task's :ref:`run method <creating-a-task-class-run-method>` processes raw or calibrated images.
+If this is not the case you can easily provide a modified argument parser.
+
+Typically this consists of constructing an instance of `lsst.pipe.base.ArgumentParser` and then adding some ID arguments to it using `~lsst.pipe.base.argumentParser.ArgumentParser.add_id_argument`.
+This is shown in several examples below.
+Please resist the urge to add other kinds of arguments to the argument parser unless truly needed.
+One strength of our tasks is how similar they are to each other.
+Learning one set of arguments suffices to use many tasks.
+
+.. warning::
+
+   If your task requires a custom argument parser to do more than just change the type of the single data reference, then it also require a :ref:`custom task runner <creating-a-command-line-task-custom-task-runner>` as well.
+
+Here are some examples:
+
+- A task's ``run`` method requires a data reference of some kind other than a raw or calibrated image.
+  This is a common case, and easily solved.
+  For example the ``processCoadd.ProcessCoaddTask`` processes co-adds, which are specified by sky map patch.
+  Here is ``ProcessCoaddTask._makeArgumentParser``:
+
+  .. code-block:: text
+
+     @classmethod
+     def _makeArgumentParser(cls):
+         """Create an argument parser
+         """
+         parser = pipeBase.ArgumentParser(name=cls._DefaultName)
+         parser.add_id_argument("--id", "deepCoadd", help="data ID, e.g. --id tract=12345 patch=1,2",
+                                ContainerClass=CoaddDataIdContainer)
+         parser.add_id_argument("--selectId", "calexp", help="data ID, e.g. --selectId visit=6789 ccd=0..9",
+                                ContainerClass=SelectDataIdContainer)
+         return parser
+
+  - The first argument to `~lsst.pipe.base.argumentParser.ArgumentParser` is the name of the ID argument.
+  - The second argument is a dataset type, which specifies the keys that are used with this ID argument.
+    The keys associated with a particular dataset type are specified in the mapper configuration file for the observatory package and camera in question, and thus may vary from camera to camera.
+    In practice, the keys for ``raw`` and ``calexp`` dataset types usually do vary from camera to camera, but the keys for coadds do not.
+    However, this is not a fixed rule.
+    For most observatory packages ``deepCoadd`` is one of two coadd dataset types, and the other, ``goodSeeingCoadd``, would work just as well for this argument.
+  - A custom ``ContainerClass`` (for example, `lsst.coadd.utils.coaddDataIdContainer.CoaddDataIdContainer`) is provided to support iterating over missing keys (e.g. if you provide a tract but not a patch then the task will iterate over all available patches for that tract).
+    This happens automatically for ``raw`` and ``calexp`` dataset types, but not most other dataset types.
+    Examine the code in `~lsst.coadd.utils.coaddDataIdContainer.CoaddDataIdContainer` to see how it works.
+
+- A task's ``run`` method requires more than one kind of data reference.
+  An example is co-addition, which requires the user to specify the co-add as a sky map patch, and optionally allows the user to specify a list of exposures to co-add.
+  `CoaddBaseTask._makeArgumentParser` is a straightforward example of specifying two data IDs arguments: one for the sky map patch, and an optional ID argument for which exposures to co-add:
+
+  .. code-block:: python
+
+     @classmethod
+     def _makeArgumentParser(cls):
+         """Create an argument parser
+         """
+         parser = pipeBase.ArgumentParser(name=cls._DefaultName)
+         parser.add_id_argument("--id", "deepCoadd", help="data ID, e.g. --id tract=12345 patch=1,2",
+                                ContainerClass=CoaddDataIdContainer)
+         parser.add_id_argument("--selectId", "calexp", help="data ID, e.g. --selectId visit=6789 ccd=0..9",
+                                ContainerClass=SelectDataIdContainer)
+         return parser
+
+  In this case the custom container class `~lsst.pipe.tasks.coaddBase.SelectDataIdContainer` adds additional information for the task, to save processing time.
+
+- A task's `run` method requires no data references at all.
+  An example is ``makeSkyMap.MakeSkyMapTask``, which makes a sky map for a set of co-adds.
+  ``makeSkyMap.MakeSkyMapTask._makeArgumentParser`` is trivial:
+
+  .. code-block:: python
+
+     @classmethod
+     def _makeArgumentParser(cls):
+         """Create an argument parser
+         No identifiers are added because none are used.
+         """
+         return pipeBase.ArgumentParser(name=cls._DefaultName)
+
+.. _creating-a-command-line-task-custom-task-runner:
+
+Custom Task Runner
+==================
+
+The standard task runner is `lsst.pipe.base.TaskRunner`.
+It assumes that your task's ``run`` method wants a single data reference and nothing else.
+If that is not the case then you will have to provide a custom task runner for your task.
+This involves writing a subclass of `lsst.pipe.base.TaskRunner` and specifying it in your task using the ``RunnerClass`` :ref:`class variable <creating-a-task-class-variables>`.
+
+Here are some situations where a custom task runner is required:
+
+- The task's ``run`` method requires extra arguments.
+  An example is co-addition, which optionally accepts a list of images to co-add.
+  The custom task runner is ``coaddBase.CoaddTaskRunner`` and is pleasantly simple:
+
+  .. code-block:: python
+
+     class CoaddTaskRunner(pipeBase.TaskRunner):
+         @staticmethod
+         def getTargetList(parsedCmd, **kwargs):
+             return pipeBase.TaskRunner.getTargetList(parsedCmd, selectDataList=parsedCmd.selectId.dataList,
+                                                      **kwargs)
+
+- The task requires no data references, just a butler.
+  An example is ``makeSkyMap.MakeSkyMapTask``, which makes a ``skymap.SkyMap`` for a set of co-adds.
+  It uses the custom task runner ``makeSkyMap.MakeSkyMapRunner``, which is more complicated than the previous example because the entire ``__call__`` method must be overridden:
+
+  .. code-block:: python
+
+     class MakeSkyMapRunner(pipeBase.TaskRunner):
+         """Only need a single butler instance to run on."""
+         @staticmethod
+         def getTargetList(parsedCmd):
+             return [parsedCmd.butler]
+         def __call__(self, butler):
+             task = self.TaskClass(config=self.config, log=self.log)
+             if self.doRaise:
+                 results = task.run(butler)
+             else:
+                 try:
+                     results = task.run(butler)
+                 except Exception as e:
+                     task.log.fatal("Failed: %s" % e)
+                     if not isinstance(e, pipeBase.TaskError):
+                         traceback.print_exc(file=sys.stderr)
+             task.writeMetadata(butler)
+             if self.doReturnResults:
+                 return results

--- a/doc/lsst.pipe.base/creating-a-task.rst
+++ b/doc/lsst.pipe.base/creating-a-task.rst
@@ -1,0 +1,351 @@
+.. TODO DM-11673 This topic should be edited into the modernized topic-based documentation style.
+.. See comments: https://github.com/lsst/pipe_base/pull/37/files#diff-292ab354e767bb472ec66e422ca6e375
+
+.. _creating-a-task:
+
+###############
+Creating a task
+###############
+
+This document describes how to write a data processing task.
+For an introduction to data processing tasks, please read :doc:`task-framework-overview`.
+It also helps to have a basic understanding of data repositories and how to use the butler to read and write data (to be written; for now read existing tasks to see how it is done).
+
+After reading this document you may wish to read :doc:`creating-a-command-line-task`.
+
+.. _creating-a-task-intro:
+
+Introduction
+============
+
+Tasks are subclasses of `lsst.pipe.base.Task` in general or `lsst.pipe.base.CmdLineTask` for command-line tasks.
+
+Tasks are constructed by calling ``__init__`` with the :ref:`task configuration <creating-a-task-configuration>`.
+Occasionally additional arguments are required (see the task's documentation for details).
+`lsst.pipe.base.Task` has a few other arguments that are usually only specified when a task is created as a subtask of another task; you will probably never have to specify them yourself.
+(Command-line tasks are often constructed and run by calling `lsst.pipe.base.parseAndRun`, as described in :doc:`creating-a-command-line-task`.)
+
+Tasks typically have a ``run`` method that executes the task's main function.
+See :ref:`creating-a-task-class-methods` for more information.
+
+.. _creating-a-task-configuration:
+
+Configuration
+=============
+
+Every task requires a configuration: a task-specific set of configuration parameters.
+The configuration is read-only; once you construct a task, the same configuration will be used to process all data with that task.
+This makes the data processing more predictable: it does not depend on the order in which items of data are processed.
+
+The task's configuration is specified using a task-specific subclass of `lsst.pex.config.Config`.
+The task class specifies its configuration class using class variable `ConfigClass`.
+If the task has no configuration parameters then it may use `lsst.pex.config.Config` as its configuration class.
+
+Some important details of configurations:
+
+- Supply useful defaults for all config parameters if at all possible.
+  Your task will be much easier to use if the default configuration usually suffices.
+
+- Document each field of the configuration carefully.
+  Pretend you don't know anything about your task and ask yourself what you would need to be told to change the parameter.
+  What does the parameter do and why might you change it?
+  What units does it have?
+
+- Subtasks are specified in your configuration as fields of type `lsst.pex.config.ConfigurableField` or (less commonly) `lsst.pex.config.RegistryField`.
+  This allows subtasks to be :doc:`retargeted <command-line-task-retargeting-howto>` (replaced with a variant subtask).
+  For more information see :ref:`creating-a-task-subtasks`.
+
+  `~lsst.pipe.tasks.exampleStatsTasks.ExampleSigmaClippedStatsTask` uses configuration class `~lsst.pipe.tasks.exampleStatsTasks.ExampleSigmaClippedStatsConfig`:
+
+  .. code-block:: python
+
+     class ExampleSigmaClippedStatsConfig(pexConfig.Config):
+         """Configuration for ExampleSigmaClippedStatsTask.
+         """
+         badMaskPlanes = pexConfig.ListField(
+             dtype=str,
+             doc="Mask planes that, if set, indicate the associated pixel should "
+             "not be included when the calculating statistics.",
+             default=("EDGE",),
+         )
+         numSigmaClip = pexConfig.Field(
+             doc="number of sigmas at which to clip data",
+             dtype=float,
+             default=3.0,
+         )
+         numIter = pexConfig.Field(
+             doc="number of iterations of sigma clipping",
+             dtype=int,
+             default=2,
+         )
+
+The configuration class is specified as ``ExampleSigmaClippedStatsTask`` class variable ``ConfigClass``, as described in :ref:`creating-a-task-class-variables`.
+
+Here is the config for ``ExampleCmdLineTask``, a task that calls one subtask named ``stats``; notice the `lsst.pex.config.ConfigurableField`:
+
+.. code-block:: python
+
+   class ExampleCmdLineConfig(pexConfig.Config):
+       """Configuration for ExampleCmdLineTask.
+       """
+       stats = pexConfig.ConfigurableField(
+           doc="Subtask to compute statistics of an image",
+           target=ExampleSigmaClippedStatsTask,
+       )
+       doFail = pexConfig.Field(
+           doc="Raise an lsst.base.TaskError exception when processing each image? "
+           + "This allows one to see the effects of the --doraise command line flag",
+           dtype=bool,
+           default=False,
+       )
+
+.. _creating-a-task-class-variables:
+
+Class variables
+===============
+
+Tasks require several class variables to function:
+
+- ``ConfigClass``: the :ref:`configuration class <creating-a-task-configuration>` used by the task.
+
+- ``_DefaultName``: a string used as the default name for the task.
+  This is required for a command-line task (`~pipe.base.cmdLineTask.CmdLineTask`), and strongly recommended for other tasks because it makes them easier to construct for unit tests.
+  Note that when a task creates a subtask, it ignores the subtask's ``_DefaultName`` and assigns the name of the config parameter as the subtask's name.
+  For example ``exampleCmdLineTask.ExampleCmdLineConfig`` creates the statistics subtask with name ``stats`` because the config field for that subtask is ``stats = lsst.pex.config.ConfigurableField(...)``.
+
+  Task names are used for the hierarchy of task and subtask metadata.
+  Also, for command-line tasks the name is used as a component of the of the dataset type for saving the task's configuration and metadata; see :ref:`creating-a-command-line-task-persisting-config-and-metadata` for more information.
+
+- ``RunnerClass``: only needed for command-line tasks; see :doc:`creating-a-command-line-task` for more information.
+
+- ``canMultiprocess``: only needed for command-line tasks; see :doc:`creating-a-command-line-task` for more information.
+
+Here are the class variables for ``ExampleCmdLineTask``:
+
+.. code-block:: python
+
+   ConfigClass = ExampleCmdLineConfig
+   _DefaultName = "exampleTask"
+
+.. _creating-a-task-class-methods:
+
+Methods
+=======
+
+Tasks have the following important methods:
+
+- :ref:`__init__ <creating-a-task-class-init-method>`: construct and initialize a task.
+- :ref:`run <creating-a-task-class-run-method>`: process one item of data.
+
+These methods are described in more depth below.
+
+.. _creating-a-task-class-init-method:
+
+The ``__init__`` method
+-----------------------
+
+Use the ``__init__`` method (task constructor) to do the following:
+
+- Call the parent task's ``__init__`` method
+- Make subtasks by calling ``self.makeSubtask(name)``, where ``name`` is the name of a field of type `lsst.pex.config.ConfigurableField` in your :ref:`task's configuration <creating-a-task-configuration>`.
+- Make a schema if your task uses an `lsst.afw.table`.
+  For an example of such a task `lsst.pipe.tasks.calibrate.CalibrateTask`.
+- Initialize any other instance variables your task needs.
+
+Here is ``exampleCmdLineTask.ExampleCmdLineTask.__init__``:
+
+.. code-block:: python
+
+   def __init__(self, *args, **kwargs):
+       """Construct an ExampleCmdLineTask
+       Call the parent class constructor and make the "stats" subtask from the config field of the same name.
+       """
+       pipeBase.CmdLineTask.__init__(self, *args, **kwargs)
+       self.makeSubtask("stats")
+
+That task creates a subtask named ``stats`` to compute image statistics.
+Here is the ``__init__`` method for the default version of the `stats` subtask:
+
+exampleTask.ExampleSigmaClippedStatsTask, which is slightly more interesting:
+
+.. code-block:: python
+
+   def __init__(self, *args, **kwargs):
+       """!Construct an ExampleSigmaClippedStatsTask
+       The init method may compute anything that that does not require data.
+       In this case we create a statistics control object using the config
+       (which cannot change once the task is created).
+       """
+       pipeBase.Task.__init__(self, *args, **kwargs)
+       self._badPixelMask = MaskU.getPlaneBitMask(self.config.badMaskPlanes)
+       self._statsControl = afwMath.StatisticsControl()
+       self._statsControl.setNumSigmaClip(self.config.numSigmaClip)
+       self._statsControl.setNumIter(self.config.numIter)
+       self._statsControl.setAndMask(self._badPixelMask)
+
+This creates a binary mask identifying bad pixels in the mask plane and an `lsst.afw.math.StatisticsControl`, specifying how statistics are computed.
+Both of these are constants, and thus are the same for each invocation of the ``run`` method; this is strongly recommended, as explained in the next section.
+
+.. _creating-a-task-class-run-method:
+
+The run method
+--------------
+
+Most tasks have a ``run`` method which perform the task's data processing operation.
+This is required for command-line tasks and strongly recommended for most other tasks.
+One exception is if your task needs different methods to handle different data types (C++ handles this using overloaded functions, but the standard technique is Python is to provide different methods for different call signatures).
+
+If your task's processing can be divided into logical units, then we recommend that you provide methods for each unit. ``run`` can then call each method to do its work.
+This allows your task to be more easily adapted: a subclass can override just a few methods.
+
+We strongly recommend that you make your task stateless, by not using instance variables as part of your data processing. Pass data between methods by calling and returning it.
+This makes the task much easier to reason about, since processing one item of data cannot affect future items of data.
+
+The ``run`` method should always return its results in an `lsst.pipe.base.struct.Struct` object, with a named field for each item of data.
+This is safer than returning a tuple of items, and allows adding fields without affecting existing code.
+Other methods should also return `~lsst.pipe.base.struct.Struct`\ s if they return more than one or two items.
+
+Any method that is likely to take significant time or memory should be preceded by this python decorator: `lsst.pipe.base.timeMethod`.
+This automatically records the execution time and memory of the method in the task's ``metadata`` attribute.
+
+The example ``exampleCmdLineTask.ExampleCmdLineTask`` is so simple that it needs no other methods; ``run`` does everything:
+
+.. code-block:: python
+
+   @pipeBase.timeMethod
+   def run(self, dataRef):
+       """Compute a few statistics on the image plane of an exposure
+       @param dataRef: data reference for a calibrated science exposure ("calexp")
+       @return a pipeBase Struct containing:
+       - mean: mean of image plane
+       - meanErr: uncertainty in mean
+       - stdDev: standard deviation of image plane
+       - stdDevErr: uncertainty in standard deviation
+       """
+       self.log.info("Processing data ID %s" % (dataRef.dataId,))
+       if self.config.doFail:
+           raise pipeBase.TaskError("Raising TaskError by request (config.doFail=True)")
+       # Unpersist the raw exposure pointed to by the data reference
+       rawExp = dataRef.get("raw")
+       maskedImage = rawExp.getMaskedImage()
+       # Support extra debug output.
+       # -
+       import lsstDebug
+       display = lsstDebug.Info(__name__).display
+       if display:
+           frame = 1
+           mtv(rawExp, frame=frame, title="exposure")
+       # return the pipe_base Struct that is returned by self.stats.run
+       return self.stats.run(maskedImage)
+
+The statistics are actually computed by the ``stats`` subtask.
+Here is the ``run`` method for the default version of that task: ``exampleTask.ExampleSigmaClippedStatsTask.run``:
+
+.. code-block:: python
+
+   @pipeBase.timeMethod
+   def run(self, maskedImage):
+       """!Compute and return statistics for a masked image
+       @param[in] maskedImage: masked image (an lsst::afw::MaskedImage)
+       @return a pipeBase Struct containing:
+       - mean: mean of image plane
+       - meanErr: uncertainty in mean
+       - stdDev: standard deviation of image plane
+       - stdDevErr: uncertainty in standard deviation
+       """
+       statObj = afwMath.makeStatistics(maskedImage, afwMath.MEANCLIP | afwMath.STDEVCLIP | afwMath.ERRORS,
+                                        self._statsControl)
+       mean, meanErr = statObj.getResult(afwMath.MEANCLIP)
+       stdDev, stdDevErr = statObj.getResult(afwMath.STDEVCLIP)
+       self.log.info("clipped mean=%0.2f; meanErr=%0.2f; stdDev=%0.2f; stdDevErr=%0.2f" %
+                     (mean, meanErr, stdDev, stdDevErr))
+       return pipeBase.Struct(
+           mean=mean,
+           meanErr=meanErr,
+           stdDev=stdDev,
+           stdDevErr=stdDevErr,
+       )
+
+.. _creating-a-task-debug-variables:
+
+Debug variables
+===============
+
+Debug variables are variables the user may set while running your task, to enable additional debug output.
+To have your task support debug variables, have it import ``lsstDebug`` and call ``lsstDebug.Info(__name__).varname`` to get the debug variable ``varname`` specific to your task.
+If you look for a variable the user has not specified, it will have a value of `False`.
+For example, to look for a debug variable named "display":
+
+.. code-block:: python
+
+   import lsstDebug
+   display = lsstDebug.Info(__name__).display
+   if display:
+      # ...
+      pass
+
+.. FIXME create link when lsstDebug documentation is ready.
+.. See \ref baseDebug for more information about debug variables, including how to specify them while running a command-line task.
+
+.. _creating-a-task-docs:
+
+Documentation
+=============
+
+To be written.
+
+.. _creating-a-task-subtasks:
+
+Subtasks
+========
+
+Each subtask is specified in the configuration as a field of type `lsst.pex.config.ConfigurableField` or (less commonly) `lsst.pex.config.RegistryField`.
+There are advantages to each:
+
+- `lsst.pex.config.ConfigurableField` advantages:
+
+  - It is easier for the user to override settings of the subtask; simply use dotted name notation:
+
+    .. code-block:: python
+
+       config.configurableSubtask.subtaskParam1 = ...
+
+    In contrast, to override configuration for a subtask specified as an `lsst.pex.config.RegistryField` you must either specify the name of the subtask to configure:
+
+    .. code-block:: python
+
+       config.registrySubtask[nameOfSelectedSubtask].subtaskParam1 = ...
+
+    Or use the `active` attribute to modify the configuration of the currently selected (active) subtask:
+
+    .. code-block:: python
+
+       config.registrySubtask.active.subtaskParam1 = ...
+
+- `lsst.pex.config.RegistryField` advantages:
+
+  - You can specify overrides for any registered subtask and they are remembered if you retarget subtasks.
+    In comparison if the subtask is specified as an `lsst.pex.config.ConfigurableField` then you can only override parameters for the currently retargeted subtask, and all overrides are lost each time you retarget.
+    Thus using an `lsst.pex.config.RegistryField` offers the opportunity to specify suitable overrides for more than one variant subtask, making it safer for the user to use those variants.
+    Of course this can get out of hand if there are many variants, so users should not assume that all variants have suitable overrides.
+
+  - Retargeting a subtask can be done using :option:`--config` on the command line, as long as the module containing the desired subtask has been imported:
+
+    .. code-block:: python
+
+       config.registrySubtask.name = "foo"
+
+    By comparison, a subtask specified as an `lsst.pex.config.ConfigurableField` can only be retargeted from a config override file (e.g. using :option:`--configfile`, never :option:`--config`):
+
+    .. code-block:: python
+
+       from ... import FooTask
+       config.configurableSubtask.retarget(FooTask)
+
+  - Variants subtasks are kept together in one registry, making it easier to find them.
+
+Our recommendation: if you anticipate that users will often wish to override the subtask with a variant, then use an `lsst.pex.config.RegistryField`.
+Otherwise use an `lsst.pex.config.ConfigurableField` to keep config overrides simpler and easier to read.
+
+For example PSF determiners and star selectors are perhaps best specified using `lsst.pex.config.RegistryField` because there are several variants users may wish to select from.
+However, calibration and instrument signature removal are best specified using  `lsst.pex.config.ConfigurableField`  because (for a given camera) there is likely to be only one logical variant, and that variant is specified in a camera-specific configuration override file, so the user need not specify it.

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -20,4 +20,5 @@ Using command-line tasks
    command-line-task-data-repo-howto.rst
    command-line-task-dataid-howto.rst
    command-line-task-logging-howto.rst
+   command-line-task-prov-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -45,3 +45,8 @@ Developing tasks and command-line tasks
 
    creating-a-task.rst
    creating-a-command-line-task.rst
+
+Python API reference
+====================
+
+.. automodapi:: lsst.pipe.base

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -18,4 +18,5 @@ Using command-line tasks
    :maxdepth: 1
 
    command-line-task-data-repo-howto.rst
+   command-line-task-dataid-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -9,6 +9,16 @@ Tasks package the algorithmic units of the LSST Science Pipelines.
 You can create, configure, and run tasks with their Python APIs.
 Some tasks, called command-line tasks, are also packaged into data processing pipelines that you can run from the command line.
 
+.. _lsst-pipe-base-overview:
+
+Overview
+========
+
+.. toctree::
+   :maxdepth: 1
+
+   task-framework-overview.rst
+
 .. _using-command-line-tasks:
 
 Using command-line tasks
@@ -24,3 +34,14 @@ Using command-line tasks
    command-line-task-logging-howto.rst
    command-line-task-parallel-howto.rst
    command-line-task-argument-reference.rst
+
+.. _lsst-pipe-base-developing-tasks:
+
+Developing tasks and command-line tasks
+=======================================
+
+.. toctree::
+   :maxdepth: 1
+
+   creating-a-task.rst
+   creating-a-command-line-task.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -11,10 +11,11 @@ Some tasks, called command-line tasks, are also packaged into data processing pi
 
 .. _using-command-line-tasks:
 
-Using command line tasks
+Using command-line tasks
 ========================
 
 .. toctree::
    :maxdepth: 1
 
+   command-line-task-data-repo-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -1,0 +1,10 @@
+.. _lsst.pipe.base:
+
+##############
+lsst.pipe.base
+##############
+
+The ``lsst.pipe.base`` module provides base classes for the task framework.
+Tasks package the algorithmic units of the LSST Science Pipelines.
+You can create, configure, and run tasks with their Python APIs.
+Some tasks, called command-line tasks, are also packaged into data processing pipelines that you can run from the command line.

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -19,4 +19,5 @@ Using command-line tasks
 
    command-line-task-data-repo-howto.rst
    command-line-task-dataid-howto.rst
+   command-line-task-logging-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -21,4 +21,5 @@ Using command-line tasks
    command-line-task-dataid-howto.rst
    command-line-task-logging-howto.rst
    command-line-task-prov-howto.rst
+   command-line-task-parallel-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -8,3 +8,13 @@ The ``lsst.pipe.base`` module provides base classes for the task framework.
 Tasks package the algorithmic units of the LSST Science Pipelines.
 You can create, configure, and run tasks with their Python APIs.
 Some tasks, called command-line tasks, are also packaged into data processing pipelines that you can run from the command line.
+
+.. _using-command-line-tasks:
+
+Using command line tasks
+========================
+
+.. toctree::
+   :maxdepth: 1
+
+   command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -19,7 +19,8 @@ Using command-line tasks
 
    command-line-task-data-repo-howto.rst
    command-line-task-dataid-howto.rst
-   command-line-task-logging-howto.rst
+   command-line-task-config-howto.rst
    command-line-task-prov-howto.rst
+   command-line-task-logging-howto.rst
    command-line-task-parallel-howto.rst
    command-line-task-argument-reference.rst

--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -30,6 +30,7 @@ Using command-line tasks
    command-line-task-data-repo-howto.rst
    command-line-task-dataid-howto.rst
    command-line-task-config-howto.rst
+   command-line-task-retargeting-howto.rst
    command-line-task-prov-howto.rst
    command-line-task-logging-howto.rst
    command-line-task-parallel-howto.rst

--- a/doc/lsst.pipe.base/task-framework-overview.rst
+++ b/doc/lsst.pipe.base/task-framework-overview.rst
@@ -1,0 +1,50 @@
+.. TODO DM-11694 This topic should be edited into the modernized topic-based documentation style.
+.. See comments: https://github.com/lsst/pipe_base/pull/37/files#diff-d12322c94d97592a5afef71fa7dd00c9
+
+.. _task-framework-overview:
+
+##############################
+Overview of the task framework
+##############################
+
+:doc:`lsst.pipe.base <index>` provides a data processing pipeline infrastructure.
+Data processing is performed by **tasks**, which are instances of `lsst.pipe.base.Task` or `lsst.pipe.base.CmdLineTask`.
+Tasks perform a wide range of data processing operations, from basic operations such as assembling raw images into CCD images (trimming overscan), fitting a WCS or detecting sources on an image, to complex combinations of such operations.
+
+**Tasks** are hierarchical.
+Each task may may call other tasks to perform some of its data processing; we say that a **parent task** calls a **subtask**.
+The highest-level task is called the **top-level task**.
+To call a subtask, the parent task constructs the subtask and then calls methods on it.
+Thus data transfer between tasks is simply a matter of passing the data as arguments to function calls.
+
+**Command-line tasks** are tasks that can be run from the command line.
+You might think of them as the LSST equivalent of a data processing pipeline.
+Despite their extra capabilities, command-line tasks can also be used as ordinary tasks and called as subtasks by other tasks.
+Command-line tasks are subclasses of `~lsst.pipe.base.CmdLineTask`.
+
+Each task is configured using the `lsst.pex.config` module, using a task-specific subclass of `lsst.pex.config.Config`.
+The task's configuration includes all subtasks that the task may call.
+As a result, it is easy to replace (or "retarget") one subtask with another.
+A common use for this is to provide a camera-specific variant of a particular task, e.g. use one version for SDSS imager data and another version for Subaru Hyper Suprime-Cam data).
+
+Tasks may process multiple items of data in parallel, using Python's `multiprocessing` library.
+Support for this is built into the `~lsst.pipe.base.ArgumentParser` and `~lsst.pipe.base.TaskRunner`.
+
+Most tasks have a ``run`` method that performs the primary data processing.
+Each task's `run` method should return a `~lsst.pipe.base.Struct`.
+This allows named access to returned data, which provides safer evolution than relying on the order of returned values.
+All task methods that return more than one or two items of data should return the data in a `~lsst.pipe.base.Struct`.
+
+Many tasks are found in the ``pipe_tasks`` package, especially tasks that use many different packages and don't seem to belong in any one of them.
+Tasks that are associated with a particular package should be in that package; for example the instrument signature removal task ``ip.isr.isrTask.IsrTask`` is in the ``ip_isr`` package.
+
+`pipe_base` is written purely in Python. The most important contents are:
+
+- `~lsst.pipe.base.CmdLineTask`: base class for pipeline tasks that can be run from the command line.
+- `~lsst.pipe.base.Task`: base class for subtasks that are not meant to be run from the
+  command line.
+- `~lsst.pipe.base.Struct`: object returned by the run method of a task.
+- `~lsst.pipe.base.ArgumentParser`: command line parser for pipeline tasks.
+- `~lsst.pipe.base.timeMethod`: decorator to log performance information for a `~lsst.pipe.base.Task` method.
+- `~lsst.pipe.base.TaskRunner`: a class that runs command-line tasks using multiprocessing when requested.
+  This will work as-is for most command-line tasks but will need to be be subclassed if, for instance, the task's run method needs something other than a single data reference.

--- a/doc/manifest.yaml
+++ b/doc/manifest.yaml
@@ -1,0 +1,5 @@
+package: "pipe_base"
+modules:
+  - "lsst.pipe.base"
+statics:
+  - "_static/pipe_base"

--- a/doc/pipe_base/index.rst
+++ b/doc/pipe_base/index.rst
@@ -1,0 +1,24 @@
+.. _pipe_base-package:
+
+#########
+pipe_base
+#########
+
+The ``pipe_base`` package provides base classes for the task framework.
+
+Project info
+============
+
+Repository
+   https://github.com/lsst/pipe_base
+
+JIRA component
+   `pipe_base <https://jira.lsstcorp.org/browse/DM/component/10727>`_.
+
+Modules
+=======
+
+- :ref:`lsst.pipe.base <lsst.pipe.base>`
+
+.. NOTE: Need pid and issuetype
+.. _`Create a ticket`: https://jira.lsstcorp.org/secure/CreateIssueDetails!init.jspa?pid=&issuetype=&components=10727

--- a/python/lsst/pipe/base/struct.py
+++ b/python/lsst/pipe/base/struct.py
@@ -27,10 +27,17 @@ __all__ = ["Struct"]
 
 
 class Struct(object):
-    """!A struct to which you can add any fields
+    """A container to which you can add fields as attributes.
 
-    Intended to be used for the return value from Task.run and other Task methods,
-    and useful for any method that returns multiple values.
+    Parameters
+    ----------
+    keyArgs
+        keyword arguments specifying fields and their values.
+
+    Notes
+    -----
+    Intended to be used for the return value from `~lsst.pipe.base.Task.run` and other `~lsst.pipe.base.Task`
+    methods, and useful for any method that returns multiple values.
 
     The intent is to allow accessing returned items by name, instead of unpacking a tuple.
     This makes the code much more robust and easier to read. It allows one to change what values are returned
@@ -38,38 +45,41 @@ class Struct(object):
     causes errors that are caught quickly and reported in a way that is easy to understand.
 
     The primary reason for using Struct instead of dict is that the fields may be accessed as attributes,
-    e.g. aStruct.foo instead of aDict["foo"]. Admittedly this only saves a few characters, but it makes
-    the code significantly more readable.
+    e.g. ``aStruct.foo`` instead of ``aDict["foo"]``. Admittedly this only saves a few characters, but it
+    makes the code significantly more readable.
 
     Struct is preferred over named tuples, because named tuples can be used as ordinary tuples, thus losing
     all the safety advantages of Struct. In addition, named tuples are clumsy to define and Structs
     are much more mutable (e.g. one can trivially combine Structs and add additional fields).
+
+    Examples
+    --------
+    >>> myStruct = Struct(
+    >>>     strVal = 'the value of the field named "strVal"',
+    >>>     intVal = 35,
+    >>> )
+
     """
 
     def __init__(self, **keyArgs):
-        """!Create a Struct with the specified field names and values
-
-        For example:
-        @code
-        myStruct = Struct(
-            strVal = 'the value of the field named "strVal"',
-            intVal = 35,
-        )
-        @endcode
-
-        @param[in] **keyArgs    keyword arguments specifying name=value pairs
-        """
         object.__init__(self)
         for name, val in keyArgs.items():
             self.__safeAdd(name, val)
 
     def __safeAdd(self, name, val):
-        """!Add a field if it does not already exist and name does not start with __ (two underscores)
+        """Add a field if it does not already exist and name does not start with ``__`` (two underscores).
 
-        @param[in] name name of field to add
-        @param[in] val  value of field to add
+        Parameters
+        ----------
+        name : `str`
+            Name of field to add.
+        val : object
+            Value of field to add.
 
-        @throw RuntimeError if name already exists or starts with __ (two underscores)
+        Raises
+        ------
+        RuntimeError
+            Raised if name already exists or starts with ``__`` (two underscores).
         """
         if hasattr(self, name):
             raise RuntimeError("Item %s already exists" % (name,))
@@ -78,29 +88,49 @@ class Struct(object):
         setattr(self, name, val)
 
     def getDict(self):
-        """!Return a dictionary of attribute name: value
+        """Get a dictionary of fields in this struct.
 
-        @warning: the values are shallow copies.
+        Returns
+        -------
+        structDict : `dict`
+            Dictionary with field names as keys and field values as values. The values are shallow copies.
         """
         return self.__dict__.copy()
 
     def mergeItems(self, struct, *nameList):
-        """!Copy specified fields from another struct, provided they don't already exist
+        """Copy specified fields from another struct, provided they don't already exist.
 
-        @param[in] struct       struct from which to copy
-        @param[in] *nameList    all remaining arguments are names of items to copy
+        Parameters
+        ----------
+        struct : `Struct`
+            `Struct` from which to copy.
+        *nameList : `str`
+            All remaining arguments are names of items to copy.
 
-        For example: foo.copyItems(other, "itemName1", "itemName2")
-        copies other.itemName1 and other.itemName2 into self.
+        Raises
+        ------
+        RuntimeError
+            Raised if any item in nameList already exists in self (but any items before the conflicting item
+            in nameList will have been copied).
 
-        @throw RuntimeError if any item in nameList already exists in self
-            (but any items before the conflicting item in nameList will have been copied)
+        Examples
+        --------
+        For example::
+
+            foo.copyItems(other, "itemName1", "itemName2")
+
+        copies ``other.itemName1`` and ``other.itemName2`` into self.
         """
         for name in nameList:
             self.__safeAdd(name, getattr(struct, name))
 
     def copy(self):
-        """!Return a one-level-deep copy (values are not copied)
+        """Make a one-level-deep copy (values are not copied).
+
+        Returns
+        -------
+        copy : `Struct`
+            One-level-deep copy of this Struct.
         """
         return Struct(**self.getDict())
 

--- a/python/lsst/pipe/base/timer.py
+++ b/python/lsst/pipe/base/timer.py
@@ -33,13 +33,21 @@ __all__ = ["logInfo", "timeMethod"]
 
 
 def logPairs(obj, pairs, logLevel=Log.DEBUG):
-    """!Log (name, value) pairs to obj.metadata and obj.log
+    """Log ``(name, value)`` pairs to ``obj.metadata`` and ``obj.log``
 
-    @param obj      a \ref task.Task "Task", or any other object with these two attributes:
-    * metadata an instance of lsst.daf.base.PropertyList (or other object with add(name, value) method)
-    * log an instance of lsst.log.Log
-    @param pairs    a collection of (name, value) pairs
-    @param logLevel log level (an lsst.log level constant, such as lsst.log.Log.DEBUG)
+    Parameters
+    ----------
+    obj : `lsst.pipe.base.Task`-type
+        A `~lsst.pipe.base.Task` or any other object with these two attributes:
+
+        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other object with
+          ``add(name, value)`` method).
+        - ``log`` an instance of `lsst.log.Log`.
+
+    pairs : sequence
+        A sequence of ``(name, value)`` pairs.
+    logLevel : optional
+        Log level (an `lsst.log` level constant, such as `lsst.log.Log.DEBUG`).
     """
     strList = []
     for name, value in pairs:
@@ -53,22 +61,32 @@ def logPairs(obj, pairs, logLevel=Log.DEBUG):
 
 
 def logInfo(obj, prefix, logLevel=Log.DEBUG):
-    """!Log timer information to obj.metadata and obj.log
+    """Log timer information to ``obj.metadata`` and ``obj.log``.
 
-    @param obj      a \ref task.Task "Task", or any other object with these two attributes:
-    * metadata an instance of lsst.daf.base.PropertyList (or other object with add(name, value) method)
-    * log an instance of lsst.log.Log
-    @param prefix   name prefix, the resulting entries are \<prefix>CpuTime, etc.
-        For example timeMethod uses prefix = \<methodName>Start
-        when the method begins and prefix = \<methodName>End when the method ends.
-    @param logLevel log level (an lsst.log level, constant such as lsst.log.Log.DEBUG)
+    Parameters
+    ----------
+    obj : `lsst.pipe.base.Task`-type
+        A `~lsst.pipe.base.Task` or any other object with these two attributes:
 
+        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other object with
+          ``add(name, value)`` method).
+        - ``log`` an instance of `lsst.log.Log`.
 
+    prefix
+        Name prefix, the resulting entries are ``CpuTime``, etc.. For example timeMethod uses
+        ``prefix = Start`` when the method begins and ``prefix = End`` when the method ends.
+    logLevel : optional
+        Log level (an `lsst.log` level constant, such as `lsst.log.Log.DEBUG`).
+
+    Notes
+    -----
     Logged items include:
-    * Utc:      UTC date in ISO format (only in metadata since log entries have timestamps)
-    * CpuTime:  CPU time (seconds)
-    * MaxRss:   maximum resident set size
-    All logged resource information is only for the current process; child processes are excluded
+
+    - ``Utc``: UTC date in ISO format (only in metadata since log entries have timestamps).
+    - ``CpuTime``: CPU time (seconds).
+    - ``MaxRss``: maximum resident set size.
+
+    All logged resource information is only for the current process; child processes are excluded.
     """
     cpuTime = time.clock()
     utcStr = datetime.datetime.utcnow().isoformat()
@@ -92,28 +110,39 @@ def logInfo(obj, prefix, logLevel=Log.DEBUG):
 
 
 def timeMethod(func):
-    """!Decorator to measure duration of a task method
+    """Decorator to measure duration of a task method.
 
-    Writes various measures of time and possibly memory usage to the task's metadata;
-    all items are prefixed with the function name.
+    Parameters
+    ----------
+    func
+        The method to wrap.
 
-    To use:
-    \code
-    import lsst.pipe.base as pipeBase
-    class FooTask(pipeBase.Task):
-        ...
+    Notes
+    -----
+    Writes various measures of time and possibly memory usage to the task's metadata; all items are prefixed
+    with the function name.
 
-        @pipeBase.timeMethod
-        def run(self, ...): # or any other instance method you want to time
-            ...
-    \endcode
+    .. warning::
 
-    @param func the method to wrap
+       This decorator only works with instance methods of Task, or any class with these attributes:
 
-    @warning This decorator only works with instance methods of Task, or any class with these attributes:
-    * metadata: an instance of lsst.daf.base.PropertyList (or other object with add(name, value) method)
-    * log: an instance of lsst.log.Log
+       - ``metadata``: an instance of `lsst.daf.base.PropertyList` (or other object with
+         ``add(name, value)`` method).
+       - ``log``: an instance of `lsst.log.Log`.
+
+    Examples
+    --------
+    To use::
+
+        import lsst.pipe.base as pipeBase
+        class FooTask(pipeBase.Task):
+            pass
+
+            @pipeBase.timeMethod
+            def run(self, ...): # or any other instance method you want to time
+                pass
     """
+
     @functools.wraps(func)
     def wrapper(self, *args, **keyArgs):
         logInfo(obj=self, prefix=func.__name__ + "Start")


### PR DESCRIPTION
This PR adds a Sphinx documentation configuration to `pipe_base`, and also adds user documentation for the command-line task infrastructure.

Key URLs:

- Homepage: https://pipelines.lsst.io/v/DM-11253/index.html
- `pipe_base` package homepage: https://pipelines.lsst.io/v/DM-11253/packages/pipe_base/index.html
- `lsst.pipe.base` module homepage: https://pipelines.lsst.io/v/DM-11253/modules/lsst.pipe.base/index.html

The [Using command-line tasks](https://pipelines.lsst.io/v/DM-11253/modules/lsst.pipe.base/index.html#using-command-line-tasks) topics are new material. The overview and developer topics are material ported from `main.dox`.

I've also converted all the docstrings in `lsst.pipe.base` to Numpydoc to give us a preview of what that is like for a `pipe_base`-scale package.