### PR TITLE
Exit to the shell with the number of failed dataRefs

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -347,6 +347,8 @@ class ArgumentParser(argparse.ArgumentParser):
         self.add_argument("--debug", action="store_true", help="enable debugging output?")
         self.add_argument("--doraise", action="store_true",
                           help="raise an exception on error (else log a message and continue)?")
+        self.add_argument("--noExit", action="store_true",
+                          help="Do not exit even upon failure (i.e. return a struct to the calling script)")
         self.add_argument("--profile", help="Dump cProfile statistics to filename")
         self.add_argument("--show", nargs="+", default=(),
                           help="display the specified information to stdout and quit "


### PR DESCRIPTION
Can be overridden using --noExit