### PR TITLE
DM-12450: Add argument parser option for reusing subtask outputs.

### DIFF
--- a/tests/test_argumentParser.py
+++ b/tests/test_argumentParser.py
@@ -529,6 +529,24 @@ class ArgumentParserTestCase(unittest.TestCase):
         with self.assertRaises(SystemExit):
             parser.parse_args(config=self.config, args=[DataPath, ])
 
+    def testReuseOption(self):
+        self.ap.addReuseOption(["a", "b", "c"])
+        namespace = self.ap.parse_args(
+            config=self.config,
+            args=[DataPath, "--reuse-outputs-from", "b"],
+        )
+        self.assertEqual(namespace.reuse, ["a", "b"])
+        namespace = self.ap.parse_args(
+            config=self.config,
+            args=[DataPath, "--reuse-outputs-from", "all"],
+        )
+        self.assertEqual(namespace.reuse, ["a", "b", "c"])
+        namespace = self.ap.parse_args(
+            config=self.config,
+            args=[DataPath],
+        )
+        self.assertEqual(namespace.reuse, [])
+
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
CmdLineTasks that wish to use this option will need to call `addReuseOption` in their `_makeArgumentParser` override, update their TaskRunner to forward the argument to their constructor, and then utilize it internally.