### PR TITLE
DM-13732: TaskRunner: ensure errors have been logged

### DIFF
--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -428,6 +428,11 @@ class TaskRunner(object):
 
                 if not isinstance(e, TaskError):
                     traceback.print_exc(file=sys.stderr)
+
+        # Ensure all errors have been logged and aren't hanging around in a buffer
+        sys.stdout.flush()
+        sys.stderr.flush()
+
         task.writeMetadata(dataRef)
 
         # remove MDC so it does not show up outside of task context


### PR DESCRIPTION
Python 3 buffers stderr, which means the exception traceback printed to
stderr might be held back until the process finishes. Instead, ensure that
it gets out promptly, before we process another element.