### PR TITLE
DM-14073: Fix up docstring syntax

### DIFF
--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -379,11 +379,11 @@ class TaskRunner(object):
             - ``dataRef``: the provided data reference.
             - ``metadata``: task metadata after execution of run.
             - ``result``: result returned by task run, or `None` if the task fails.
-            - ``exitStatus`: 0 if the task completed successfully, 1 otherwise.
+            - ``exitStatus``: 0 if the task completed successfully, 1 otherwise.
 
             If ``doReturnResults`` is `False` the struct contains:
 
-            - ``exitStatus`: 0 if the task completed successfully, 1 otherwise.
+            - ``exitStatus``: 0 if the task completed successfully, 1 otherwise.
 
         Notes
         -----
@@ -452,7 +452,7 @@ class TaskRunner(object):
 
 
 class ButlerInitializedTaskRunner(TaskRunner):
-    """A TaskRunner for `CmdLineTask`\ s that require a ``butler`` keyword argument to be passed to
+    """A `TaskRunner` for `CmdLineTask`\ s that require a ``butler`` keyword argument to be passed to
     their constructor.
     """
 

--- a/python/lsst/pipe/base/task.py
+++ b/python/lsst/pipe/base/task.py
@@ -100,6 +100,7 @@ class Task(object):
       Iteration, if desired, is performed by a caller of the run method. This is good design and allows
       multiprocessing without the run method having to support it directly.
     - If ``run`` can persist or unpersist data:
+
       - ``run`` should accept a butler data reference (or a collection of data references, if appropriate,
         e.g. coaddition).
       - There should be a way to run the task without persisting data. Typically the run method returns all


### PR DESCRIPTION
Fixes an unclosed inline literal in `TaskRunner` and a sub-list issue in `Task`.