### PR TITLE
DM-14359: Fix data ID handling in ap_*

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -159,11 +159,8 @@ class DataIdContainer(object):
             raise RuntimeError("Must call setDatasetType first")
         butler = namespace.butler
         for dataId in self.idList:
-            refList = list(butler.subset(datasetType=self.datasetType, level=self.level, dataId=dataId))
-            # exclude nonexistent data
-            # this is a recursive test, e.g. for the sake of "raw" data
-            refList = [dr for dr in refList if dataExists(butler=butler, datasetType=self.datasetType,
-                                                          dataRef=dr)]
+            refList = dafPersist.searchDataRefs(butler, datasetType=self.datasetType,
+                                                level=self.level, dataId=dataId)
             if not refList:
                 namespace.log.warn("No data found for dataId=%s", dataId)
                 continue
@@ -1222,30 +1219,3 @@ def getDottedAttr(item, name):
     for subname in name.split("."):
         subitem = getattr(subitem, subname)
     return subitem
-
-
-def dataExists(butler, datasetType, dataRef):
-    """Determine if data exists at the current level or any data exists at a deeper level.
-
-    Parameters
-    ----------
-    butler : `lsst.daf.persistence.Butler`
-        The Butler.
-    datasetType : `str`
-        Dataset type.
-    dataRef : `lsst.daf.persistence.ButlerDataRef`
-        Butler data reference.
-
-    Returns
-    -------
-    exists : `bool`
-        Return value is `True` if data exists, `False` otherwise.
-    """
-    subDRList = dataRef.subItems()
-    if subDRList:
-        for subDR in subDRList:
-            if dataExists(butler, datasetType, subDR):
-                return True
-        return False
-    else:
-        return butler.datasetExists(datasetType=datasetType, dataId=dataRef.dataId)

--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -45,9 +45,6 @@ def _runPool(pool, timeout, function, iterable):
 
     This is required so as to trigger an immediate interrupt on the KeyboardInterrupt (Ctrl-C); see
     http://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
-
-    Further wraps the function in ``_poolFunctionWrapper`` to catch exceptions
-    that don't inherit from `Exception`.
     """
     return pool.map_async(function, iterable).get(timeout)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E228, N802, N803, N806
+ignore = E133, E226, E228, N802, N803, N806
 exclude =
     __init__.py,
     tests/data/*


### PR DESCRIPTION
This PR factors out data ID expansion and verification from `DataRefContainer`, moving it into `daf_persistence` so that it can be used by other code.

This PR must be merged after lsst/daf_persistence#93.