### PR TITLE
Use delayed StorageClass instantiation (DM-15887)

### DIFF
--- a/python/lsst/pipe/base/pipelineTask.py
+++ b/python/lsst/pipe/base/pipelineTask.py
@@ -24,7 +24,7 @@
 
 __all__ = ["DatasetTypeDescriptor", "PipelineTask"]  # Classes in this module
 
-from lsst.daf.butler import DatasetType, StorageClassFactory
+from lsst.daf.butler import DatasetType
 from .config import (InputDatasetConfig, OutputDatasetConfig,
                      InitInputDatasetConfig, InitOutputDatasetConfig)
 from .task import Task
@@ -79,12 +79,9 @@ class DatasetTypeDescriptor:
         -------
         descriptor : `DatasetTypeDescriptor`
         """
-        # map storage class name to storage class
-        storageClass = StorageClassFactory().getStorageClass(datasetConfig.storageClass)
-
         datasetType = DatasetType(name=datasetConfig.name,
                                   dataUnits=datasetConfig.units,
-                                  storageClass=storageClass)
+                                  storageClass=datasetConfig.storageClass)
         # Use scalar=True for Init dataset types
         scalar = getattr(datasetConfig, 'scalar', True)
         return cls(datasetType=datasetType, scalar=scalar)

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -25,8 +25,7 @@
 import unittest
 
 import lsst.utils.tests
-from lsst.daf.butler import (DatasetRef, DatasetType, Quantum, Run,
-                             StorageClass, StorageClassFactory)
+from lsst.daf.butler import DatasetRef, DatasetType, Quantum, Run
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
 
@@ -51,7 +50,6 @@ class ButlerMock():
         else:
             dsTypeName = datasetRefOrType
         key = self.key(dataId)
-#         print("butler.get: name={} key={}".format(ref.datasetType.name, key))
         dsdata = self.datasets.get(dsTypeName)
         if dsdata:
             return dsdata.get(key)
@@ -59,7 +57,6 @@ class ButlerMock():
 
     def put(self, inMemoryDataset, dsTypeName, dataId, producer=None):
         key = self.key(dataId)
-#         print("butler.put: {} -> name={} key={}".format(inMemoryDataset, ref.datasetType.name, key))
         dsdata = self.datasets.setdefault(dsTypeName, {})
         dsdata[key] = inMemoryDataset
 
@@ -109,17 +106,12 @@ class DatasetTypeDescriptorTestCase(unittest.TestCase):
     """A test case for DatasetTypeDescriptor
     """
 
-    @classmethod
-    def setUpClass(cls):
-        StorageClassFactory().registerStorageClass(StorageClass("example"))
-
     def testConstructor(self):
         """Test DatasetTypeDescriptor init
         """
-        storageClass = StorageClassFactory().getStorageClass("example")
         datasetType = DatasetType(name="testDataset",
                                   dataUnits=["UnitA"],
-                                  storageClass=storageClass)
+                                  storageClass="example")
         descriptor = pipeBase.DatasetTypeDescriptor(datasetType=datasetType,
                                                     scalar=False)
         self.assertIs(descriptor.datasetType, datasetType)
@@ -148,10 +140,6 @@ class DatasetTypeDescriptorTestCase(unittest.TestCase):
 class PipelineTaskTestCase(unittest.TestCase):
     """A test case for PipelineTask
     """
-
-    @classmethod
-    def setUpClass(cls):
-        StorageClassFactory().registerStorageClass(StorageClass("example"))
 
     def _makeDSRefVisit(self, dstype, visitId):
         return DatasetRef(datasetType=dstype,


### PR DESCRIPTION
DatasetType can now be constructed using StorageClass name instead of
instance. Use this to avoid explicit StorageClass instantiation using
StorageClassFactory.