### PR TITLE
tickets/DM-14819

### DIFF
--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -129,7 +129,8 @@ def _makeDatasetField(name, dtype):
         extraFields = ""
     elif issubclass(dtype, _DatasetTypeConfig):
         # Handle dataset types like InputDatasetConfig, note these take a dimensions argument
-        def wrappedFunc(*, doc, dimensions, storageClass, name="", scalar=False, check=None, nameTemplate=''):
+        def wrappedFunc(*, doc, dimensions, storageClass, name="", scalar=False, check=None, nameTemplate='',
+                        manualLoad=False):
             return factory(**{k: v for k, v in locals().items() if k != 'factory'})
         # Set the string corresponding to the dimensions parameter documentation
         # formatting is to support final output of the docstring variable
@@ -145,11 +146,15 @@ def _makeDatasetField(name, dtype):
                 Template for the `name` field which is specified as a python formattable
                 string. The template is formatted during the configuration of a Config
                 class with a user defined string. Defaults to empty string, in which
-                case no formatting is done."""
+                case no formatting is done.
+            manualLoad : `bool`
+                Indicates runQuantum will not load the data from the butler, and that
+                the task intends to do the loading itself. Defaults to False
+            """
         # Set a string to add the dimensions argument to the list of arguments in the
         # docstring explanation section formatting is to support final output
         # of the docstring variable
-        extraFields = ", dimensions, scalar, nameTemplate"
+        extraFields = ", dimensions, scalar, nameTemplate, manualLoad"
     else:
         # if someone tries to create a config factory for a type that is not
         # handled raise and exception
@@ -245,6 +250,13 @@ class _DatasetTypeConfig(_BaseDatasetTypeConfig):
                                   "objects/DataIds will be unpacked before calling task "
                                   "methods, returned data is expected to contain single "
                                   "objects as well."))
+    manualLoad = pexConfig.Field(dtype=bool,
+                                 default=False,
+                                 optional=True,
+                                 doc=("If this is set to True, the class intends to load "
+                                      "the data associated with this Configurable Field "
+                                      "manually, and runQuantum should not load it. Should "
+                                      "not be set by configuration override"))
 
 
 class InputDatasetConfig(_DatasetTypeConfig):

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -337,6 +337,7 @@ class GraphBuilder(object):
                     for key in dataRefs.keys():
                         if dataRefs[key].id is not None:
                             dataRefs[key] = self.registry.getDataset(dataRefs[key].id)
+                            self.registry.expandDataId(dataRefs[key].dataId, region=True)
 
             # all nodes for this task
             quanta = []

--- a/python/lsst/pipe/base/pipelineTask.py
+++ b/python/lsst/pipe/base/pipelineTask.py
@@ -61,9 +61,10 @@ class DatasetTypeDescriptor:
         `True` if this is a scalar dataset.
     """
 
-    def __init__(self, datasetType, scalar):
+    def __init__(self, datasetType, scalar, manualLoad):
         self._datasetType = datasetType
         self._scalar = scalar
+        self._manualLoad = manualLoad
 
     @classmethod
     def fromConfig(cls, datasetConfig):
@@ -84,7 +85,8 @@ class DatasetTypeDescriptor:
                                   storageClass=datasetConfig.storageClass)
         # Use scalar=True for Init dataset types
         scalar = getattr(datasetConfig, 'scalar', True)
-        return cls(datasetType=datasetType, scalar=scalar)
+        manualLoad = getattr(datasetConfig, 'manualLoad', False)
+        return cls(datasetType=datasetType, scalar=scalar, manualLoad=manualLoad)
 
     @property
     def datasetType(self):
@@ -97,6 +99,12 @@ class DatasetTypeDescriptor:
         """`True` if this is a scalar dataset.
         """
         return self._scalar
+
+    @property
+    def manualLoad(self):
+        """`True` if the task will handle loading the data
+        """
+        return self._manualLoad
 
 
 class PipelineTask(Task):
@@ -478,7 +486,8 @@ class PipelineTask(Task):
                     keyDataRefs = keyDataRefs[0]
                     keyDataIds = keyDataIds[0]
                 dataIds[key] = keyDataIds
-                dataRefs[key] = keyDataRefs
+                if not descriptor.manualLoad:
+                    dataRefs[key] = keyDataRefs
             return dataIds, dataRefs
 
         # lists of DataRefs/DataIds for input datasets

--- a/tests/test_pipeTools.py
+++ b/tests/test_pipeTools.py
@@ -40,7 +40,7 @@ DS = namedtuple("DS", "name dimensions")
 # stick a trivial (mock) implementation here.
 def makeDatasetTypeDescr(dsConfig):
     datasetType = DS(name=dsConfig.name, dimensions=dsConfig.dimensions)
-    return DatasetTypeDescriptor(datasetType, scalar=False)
+    return DatasetTypeDescriptor(datasetType, scalar=False, manualLoad=False)
 
 
 class ExamplePipelineTaskConfig(PipelineTaskConfig):

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -113,12 +113,14 @@ class DatasetTypeDescriptorTestCase(unittest.TestCase):
                                   dimensions=["UnitA"],
                                   storageClass="example")
         descriptor = pipeBase.DatasetTypeDescriptor(datasetType=datasetType,
-                                                    scalar=False)
+                                                    scalar=False,
+                                                    manualLoad=False)
         self.assertIs(descriptor.datasetType, datasetType)
         self.assertFalse(descriptor.scalar)
 
         descriptor = pipeBase.DatasetTypeDescriptor(datasetType=datasetType,
-                                                    scalar=True)
+                                                    scalar=True,
+                                                    manualLoad=False)
         self.assertIs(descriptor.datasetType, datasetType)
         self.assertTrue(descriptor.scalar)
 


### PR DESCRIPTION
Allow DatasetType to be marked for later load

Although DatasetTypes need to be known prior to task execution to
build a QuantumGraph, not all data products need to be loaded before
task execution. This change introduces a way to indicate a
DatasetType will be manually read in and handled by a task.