### PR TITLE
DM-15201: Forward Python logging to lsst.log

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -27,6 +27,7 @@ import argparse
 import collections
 import fnmatch
 import itertools
+import logging
 import os
 import re
 import shlex
@@ -500,6 +501,11 @@ log4j.appender.A1.Target=System.out
 log4j.appender.A1.layout=PatternLayout
 log4j.appender.A1.layout.ConversionPattern=%c %p: %m%n
 """)
+
+        # Forward all Python logging to lsst.log
+        lgr = logging.getLogger()
+        lgr.setLevel(logging.DEBUG)
+        lgr.addHandler(lsstLog.LogHandler())
 
     def add_id_argument(self, name, datasetType, help, level=None, doMakeDataRefList=True,
                         ContainerClass=DataIdContainer):


### PR DESCRIPTION
Use lsst.log.LogHandler to setup message forwarding to lsst.log in
argumentParser.