### PR TITLE
DM-17741: Improve logging forwarding setup

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -504,7 +504,7 @@ log4j.appender.A1.layout.ConversionPattern=%c %p: %m%n
 
         # Forward all Python logging to lsst.log
         lgr = logging.getLogger()
-        lgr.setLevel(logging.DEBUG)
+        lgr.setLevel(logging.INFO)  # same as in log4cxx config above
         lgr.addHandler(lsstLog.LogHandler())
 
     def add_id_argument(self, name, datasetType, help, level=None, doMakeDataRefList=True,
@@ -1279,6 +1279,10 @@ class LogLevelAction(argparse.Action):
                 namespace.log.setLevel(logLevel)
             else:
                 lsstLog.Log.getLogger(component).setLevel(logLevel)
+            # Python logging levels are same as lsst.log divided by 1000,
+            # logging does not have TRACE level by default but it is OK to use
+            # that numeric level and we may even add TRACE later.
+            logging.getLogger(component).setLevel(logLevel//1000)
 
 
 class ReuseAction(argparse.Action):

--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -1279,10 +1279,9 @@ class LogLevelAction(argparse.Action):
                 namespace.log.setLevel(logLevel)
             else:
                 lsstLog.Log.getLogger(component).setLevel(logLevel)
-            # Python logging levels are same as lsst.log divided by 1000,
-            # logging does not have TRACE level by default but it is OK to use
-            # that numeric level and we may even add TRACE later.
-            logging.getLogger(component).setLevel(logLevel//1000)
+            # set logging level for Python logging
+            pyLevel = lsstLog.LevelTranslator.lsstLog2logging(logLevel)
+            logging.getLogger(component).setLevel(pyLevel)
 
 
 class ReuseAction(argparse.Action):


### PR DESCRIPTION
Previous assumption that root logger has no handlers does not hold in
case of pytest, resulting in a lot of messages generated by unit test.
Fix is to set default logging level for root logger to INFO (like for
lsst.log) and then adjust levels for individual loggers in sync for both
lsst.log and logging.