### PR TITLE
fixed OpenBLAS and MKL links

### DIFF
--- a/doc/lsst.pipe.base/command-line-task-parallel-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-parallel-howto.rst
@@ -98,5 +98,5 @@ For example, in a :command:`bash` shell:
    - `lsst.base.getNumThreads`
    - `lsst.base.setNumThreads`
 
-.. _OpenBLAS: http://www.openblas.net
-.. _MKL: http://www.openblas.net
+.. _OpenBLAS: https://www.openblas.net
+.. _MKL: https://software.intel.com/en-us/mkl


### PR DESCRIPTION
Tiny fix: while reading the documentation, I noticed the MKL link mistakenly pointed to the OpenBLAS homepage.

Another fix: The OpenBLAS link now uses `https`.