### PR TITLE
DM-21859: Use correct quantumDataId for PrerequisiteInputs.

### DIFF
--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -660,7 +660,7 @@ class _PipelineScaffolding:
                         registry.queryDatasets(
                             datasetType,
                             collections=inputCollections[datasetType.name],
-                            dataId=dataId,
+                            dataId=quantumDataId,
                             deduplicate=True,
                             expand=True,
                         )


### PR DESCRIPTION
The current code uses `dataId`, which is set in a previous loop and is
not the appropriate value.