### PR TITLE
DM-22162: Add metadata writing to PipelineTask execution logic (pipe_base)

### DIFF
--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -123,7 +123,14 @@ class PipelineTaskConfig(pexConfig.Config, metaclass=PipelineTaskConfigMeta):
     created config class is then attached to the `PipelineTaskConfig` via a
     `~lsst.pex.config.ConfigField` with the attribute name `connections`.
     """
-    pass
+    metadataDataset = pexConfig.ChoiceField(
+        dtype=str,
+        doc="Choice for the name of metadata dataset.",
+        allowed={"label": "Use task label in dataset name, \"<label>_metadata\".",
+                 "taskName": "Use task name in dataset name, \"<taskName>_metadata\".",
+                 None: "Disables writing of task metadata."},
+        default="label",
+        optional=True)
 
 
 class ResourceConfig(pexConfig.Config):

--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -123,14 +123,9 @@ class PipelineTaskConfig(pexConfig.Config, metaclass=PipelineTaskConfigMeta):
     created config class is then attached to the `PipelineTaskConfig` via a
     `~lsst.pex.config.ConfigField` with the attribute name `connections`.
     """
-    metadataDataset = pexConfig.ChoiceField(
-        dtype=str,
-        doc="Choice for the name of metadata dataset.",
-        allowed={"label": "Use task label in dataset name, \"<label>_metadata\".",
-                 "taskName": "Use task name in dataset name, \"<taskName>_metadata\".",
-                 None: "Disables writing of task metadata."},
-        default="label",
-        optional=True)
+    saveMetadata = pexConfig.Field(
+        dtype=bool, default=True, optional=False,
+        doc="Flag to enable/disable metadata saving for a task, enabled by default.")
 
 
 class ResourceConfig(pexConfig.Config):

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -356,7 +356,7 @@ class PipelineTaskConnections(metaclass=PipelineTaskConnectionsMetaclass):
     >>> config.connections.outputConnection = "TotallyDifferent"
     >>> connections = ExampleConnections(config=config)
     >>> assert(connections.inputConnection.name == "ModifiedDataset")
-    >>> assert(connections.outputCOnnection.name == "TotallyDifferent")
+    >>> assert(connections.outputConnection.name == "TotallyDifferent")
     """
 
     def __init__(self, *, config: 'PipelineTaskConfig' = None):

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -236,6 +236,7 @@ class _TaskScaffolding:
             raise GraphBuilderError(f"Task with label '{taskDef.label}' has dimensions "
                                     f"{self.dimensions} that are not a subset of "
                                     f"the pipeline dimensions {parent.dimensions}.")
+
         # Initialize _DatasetScaffoldingDicts as subsets of the one or two
         # corresponding dicts in the parent _PipelineScaffolding.
         self.initInputs = _DatasetScaffoldingDict.fromSubset(datasetTypes.initInputs,

--- a/python/lsst/pipe/base/pipeline.py
+++ b/python/lsst/pipe/base/pipeline.py
@@ -92,15 +92,10 @@ class TaskDef:
         """Name of a dataset type for metadata of this task, `None` if
         metadata is not to be saved (`str`)
         """
-        if self.config.metadataDataset == "label":
+        if self.config.saveMetadata:
             return self.label + "_metadata"
-        elif self.config.metadataDataset == "taskName":
-            return self.taskName + "_metadata",
-        elif self.config.metadataDataset is None:
-            return None
         else:
-            raise ValueError("Unexpected value of config.metadataDataset = " +
-                             str(self.config.metadataDataset))
+            return None
 
     def __str__(self):
         rep = "TaskDef(" + self.taskName

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,12 +30,18 @@ from lsst.daf.butler import StorageClass, StorageClassFactory
 import lsst.pipe.base as pipeBase
 
 
+class NullConnections(pipeBase.PipelineTaskConnections,
+                      dimensions=()):
+    pass
+
+
 class NoResourceTask(pipeBase.PipelineTask):
     _DefaultName = "no_resource_task"
-    ConfigClass = pexConfig.Config
+    ConfigClass = pipeBase.PipelineTaskConfig
 
 
-class OneConfig(pexConfig.Config):
+class OneConfig(pipeBase.PipelineTaskConfig,
+                pipelineConnections=NullConnections):
     resources = pexConfig.ConfigField(dtype=pipeBase.ResourceConfig,
                                       doc="Resource configuration")
 
@@ -45,7 +51,8 @@ class OneTask(pipeBase.PipelineTask):
     ConfigClass = OneConfig
 
 
-class TwoConfig(pexConfig.Config):
+class TwoConfig(pipeBase.PipelineTaskConfig,
+                pipelineConnections=NullConnections):
     resources = pexConfig.ConfigField(dtype=pipeBase.ResourceConfig,
                                       doc="Resource configuration")
 
@@ -92,6 +99,18 @@ class TaskTestCase(unittest.TestCase):
         self.assertIsNot(res_config, None)
         self.assertEqual(res_config.minMemoryMB, 1024)
         self.assertEqual(res_config.minNumCores, 32)
+
+    def testMetadataDataset(self):
+        """Test for metadata dataset configuration.
+        """
+        config = pipeBase.PipelineTaskConfig()
+        self.assertEqual(config.metadataDataset, "label")
+        config.metadataDataset = "taskName"
+        self.assertEqual(config.metadataDataset, "taskName")
+        config.metadataDataset = None
+        self.assertIsNone(config.metadataDataset)
+        with self.assertRaises(pexConfig.FieldValidationError):
+            config.metadataDataset = ""
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,18 +100,6 @@ class TaskTestCase(unittest.TestCase):
         self.assertEqual(res_config.minMemoryMB, 1024)
         self.assertEqual(res_config.minNumCores, 32)
 
-    def testMetadataDataset(self):
-        """Test for metadata dataset configuration.
-        """
-        config = pipeBase.PipelineTaskConfig()
-        self.assertEqual(config.metadataDataset, "label")
-        config.metadataDataset = "taskName"
-        self.assertEqual(config.metadataDataset, "taskName")
-        config.metadataDataset = None
-        self.assertIsNone(config.metadataDataset)
-        with self.assertRaises(pexConfig.FieldValidationError):
-            config.metadataDataset = ""
-
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -86,6 +86,9 @@ class TaskTestCase(unittest.TestCase):
         self.assertIsInstance(task2.config, MultConfig)
         self.assertIs(task2.taskClass, MultTask)
         self.assertEqual(task2.label, "mult_task")
+        self.assertEqual(task2.metadataDatasetName, "mult_task_metadata")
+        task2.config.saveMetadata = False
+        self.assertIsNone(task2.metadataDatasetName)
 
     def testEmpty(self):
         """Creating empty pipeline


### PR DESCRIPTION
Add support for a special dataset type to store task metadata. The dataset type is added to quantum outputs like regular dataset so that other tasks can specify it as an input. The dataset type does not appear in standard connections config, instead it is added dynamically based on task config parameter `saveMetadata` (bool).