### PR TITLE
DM-22599: Develop PipelineTask unit test framework

### DIFF
--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -69,3 +69,6 @@ Python API reference
 
 .. automodapi:: lsst.pipe.base
    :no-main-docstr:
+.. automodapi:: lsst.pipe.base.tests
+   :no-main-docstr:
+   :no-inheritance-diagram:

--- a/python/lsst/pipe/base/tests.py
+++ b/python/lsst/pipe/base/tests.py
@@ -111,7 +111,18 @@ def _makeRecords(dataIds, universe):
         for value in values:
             expandedValue = {}
             for key in dimension.uniqueKeys:
-                expandedValue[key.name] = key.dtype().python_type(value)
+                if key.nbytes:
+                    castType = bytes
+                else:
+                    castType = key.dtype().python_type
+                try:
+                    castValue = castType(value)
+                except TypeError:
+                    castValue = castType()
+                expandedValue[key.name] = castValue
+            for key in dimension.metadata:
+                if not key.nullable:
+                    expandedValue[key.name] = key.dtype().python_type(value)
             expandedIds[name].append(expandedValue)
 
     # Pick cross-relationships arbitrarily

--- a/python/lsst/pipe/base/tests.py
+++ b/python/lsst/pipe/base/tests.py
@@ -33,11 +33,11 @@ def makeTestButler(root, dataIds):
     ----------
     root : `str`
         The location of the root directory for the repository.
-    dataIds : `~collections.abc.Mapping` [`str`, `iterable` [`~collections.abc.Mapping`]]
+    dataIds : `~collections.abc.Mapping` [`str`, `iterable`]
         A mapping keyed by the dimensions used in the test. Each value
-        is a mapping of fields and values for that dimension. See
-        :file:`daf/butler/config/dimensions.yaml` for required fields,
-        listed as "keys" and "requires" under each dimension's entry.
+        is an iterable of names for that dimension (e.g., detector IDs for
+        `"detector"`). Related dimensions (e.g., instruments and detectors)
+        are linked arbitrarily.
 
     Returns
     -------
@@ -48,9 +48,59 @@ def makeTestButler(root, dataIds):
     #     with test-level runs after DM-21246
     Butler.makeRepo(root)
     butler = Butler(root, run="test")
-    for dimension, values in dataIds.items():
-        butler.registry.insertDimensionData(dimension, *values)
+    dimensionRecords = _makeRecords(dataIds, butler.registry.dimensions)
+    for dimension, records in dimensionRecords.items():
+        butler.registry.insertDimensionData(dimension, *records)
     return butler
+
+
+def _makeRecords(dataIds, universe):
+    """Create cross-linked dimension records from a collection of
+    data ID values.
+
+    Parameters
+    ----------
+    dataIds : `~collections.abc.Mapping` [`str`, `iterable`]
+        A mapping keyed by the dimensions of interest. Each value is an
+        iterable of names for that dimension (e.g., detector IDs for
+        `"detector"`).
+    universe : lsst.daf.butler.DimensionUniverse
+        Set of all known dimensions and their relationships.
+
+    Returns
+    -------
+    dataIds : `~collections.abc.Mapping` [`str`, `iterable` [`~lsst.daf.butler.DimensionRecord`]]
+        A mapping keyed by the dimensions of interest, giving one dimension
+        record for each input name. Related dimensions (e.g., instruments and
+        detectors) are linked arbitrarily.
+    """
+    expandedIds = {}
+    # Provide alternate keys like detector names
+    for name, values in dataIds.items():
+        expandedIds[name] = []
+        dimension = universe[name]
+        for value in values:
+            expandedValue = {}
+            for key in dimension.uniqueKeys:
+                expandedValue[key.name] = key.dtype().python_type(value)
+            expandedIds[name].append(expandedValue)
+
+    # Pick cross-relationships arbitrarily
+    for name, values in expandedIds.items():
+        dimension = universe[name]
+        for value in values:
+            for other in dimension.graph.required:
+                if other != dimension:
+                    relation = expandedIds[other.name][0]
+                    value[other.name] = relation[other.primaryKey.name]
+            # Do not recurse, to keep the user from having to provide irrelevant dimensions
+            for other in dimension.implied:
+                if other != dimension and other.name in expandedIds and other.viewOf is None:
+                    relation = expandedIds[other.name][0]
+                    value[other.name] = relation[other.primaryKey.name]
+
+    return {dimension: [universe[dimension].RecordClass.fromDict(value) for value in values]
+            for dimension, values in expandedIds.items()}
 
 
 def makeDatasetType(butler, name, dimensions, storageClass):

--- a/python/lsst/pipe/base/tests.py
+++ b/python/lsst/pipe/base/tests.py
@@ -1,0 +1,86 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["makeTestButler", "makeDatasetType"]
+
+
+from lsst.daf.butler import Butler, DatasetType
+
+
+def makeTestButler(root, dataIds):
+    """Create an empty repository with default configuration.
+
+    Parameters
+    ----------
+    root : `str`
+        The location of the root directory for the repository.
+    dataIds : `~collections.abc.Mapping` [`str`, `iterable` [`~collections.abc.Mapping`]]
+        A mapping keyed by the dimensions used in the test. Each value
+        is a mapping of fields and values for that dimension. See
+        :file:`daf/butler/config/dimensions.yaml` for required fields,
+        listed as "keys" and "requires" under each dimension's entry.
+
+    Returns
+    -------
+    butler : `lsst.daf.butler.Butler`
+        A Butler referring to the new repository.
+    """
+    # TODO: takes 5 seconds to run; split up into class-level Butler
+    #     with test-level runs after DM-21246
+    Butler.makeRepo(root)
+    butler = Butler(root, run="test")
+    for dimension, values in dataIds.items():
+        butler.registry.insertDimensionData(dimension, *values)
+    return butler
+
+
+def makeDatasetType(butler, name, dimensions, storageClass):
+    """Create a dataset type in a particular repository.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The repository to update.
+    name : `str`
+        The name of the dataset type.
+    dimensions : `set` [`str`]
+        The dimensions of the new dataset type.
+    storageClass : `str`
+        The storage class the dataset will use.
+
+    Returns
+    -------
+    datasetType : `lsst.daf.butler.DatasetType`
+        The new type.
+
+    Raises
+    ------
+    ValueError
+        Raised if the dimensions or storage class is invalid.
+    """
+    try:
+        datasetType = DatasetType(name, dimensions, storageClass,
+                                  universe=butler.registry.dimensions)
+        butler.registry.registerDatasetType(datasetType)
+        return datasetType
+    except KeyError as e:
+        raise ValueError from e

--- a/python/lsst/pipe/base/tests.py
+++ b/python/lsst/pipe/base/tests.py
@@ -25,6 +25,7 @@ __all__ = ["makeTestRepo", "makeUniqueButler", "makeDatasetType", "expandUniqueI
 
 
 import collections.abc
+import unittest.mock
 
 import numpy as np
 
@@ -321,7 +322,7 @@ def _refFromConnection(butler, connection, dataId, **kwargs):
             from e
 
 
-def runQuantum(task, butler, quantum):
+def runQuantum(task, butler, quantum, mockRun=True):
     """Run a PipelineTask on a Quantum.
 
     Parameters
@@ -332,8 +333,25 @@ def runQuantum(task, butler, quantum):
         The collection to run on.
     quantum : `lsst.daf.butler.Quantum`
         The quantum to run.
+    mockRun : `bool`
+        Whether or not to replace ``task``'s ``run`` method. The default of
+        `True` is recommended unless ``run`` needs to do real work (e.g.,
+        because the test needs real output datasets).
+
+    Returns
+    -------
+    run : `unittest.mock.Mock` or `None`
+        If ``mockRun`` is set, the mock that replaced ``run``. This object can
+        be queried for the arguments ``runQuantum`` passed to ``run``.
     """
     butlerQc = ButlerQuantumContext(butler, quantum)
     connections = task.config.ConnectionsClass(config=task.config)
     inputRefs, outputRefs = connections.buildDatasetRefs(quantum)
-    task.runQuantum(butlerQc, inputRefs, outputRefs)
+    if mockRun:
+        with unittest.mock.patch.object(task, "run") as mock, \
+                unittest.mock.patch("lsst.pipe.base.ButlerQuantumContext.put"):
+            task.runQuantum(butlerQc, inputRefs, outputRefs)
+            return mock
+    else:
+        task.runQuantum(butlerQc, inputRefs, outputRefs)
+        return None

--- a/tests/test_pipelineTaskTests.py
+++ b/tests/test_pipelineTaskTests.py
@@ -1,0 +1,117 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Unit tests for `lsst.pipe.base.tests`, a library for testing
+PipelineTask subclasses.
+"""
+
+import shutil
+import tempfile
+import unittest
+
+import lsst.utils.tests
+import lsst.daf.butler
+
+from lsst.pipe.base.tests import makeTestButler, makeDatasetType
+
+
+class ButlerUtilsTestSuite(lsst.utils.tests.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Butler or collection should be re-created for each test case, but
+        # this has a prohibitive run-time cost at present
+        cls.root = tempfile.mkdtemp()
+
+        dataIds = {}
+        dataIds["instrument"] = [{"name": "notACam"}]
+        dataIds["physical_filter"] = [{
+            "name": "k2020",
+            "instrument": "notACam",
+        }]
+        dataIds["visit"] = [{
+            "id": 101,
+            "name": "unique_visit",
+            "instrument": "notACam",
+            "physical_filter": "k2020",
+        }]
+        dataIds["detector"] = [{
+            "id": 5,
+            "full_name": "chip_5",
+            "instrument": "notACam",
+        }]
+        cls.butler = makeTestButler(cls.root, dataIds)
+
+        makeDatasetType(cls.butler, "DataType1", {"instrument"}, "NumpyArray")
+        makeDatasetType(cls.butler, "DataType2", {"instrument", "visit", "detector"}, "NumpyArray")
+
+    @classmethod
+    def tearDownClass(cls):
+        # TODO: use addClassCleanup rather than tearDownClass in Python 3.8
+        #    to keep the addition and removal together
+        shutil.rmtree(cls.root, ignore_errors=True)
+
+    def testButlerValid(self):
+        self.butler.validateConfiguration()
+
+    def _checkButlerDimension(self, dimensions, query, expected):
+        result = [id for id in self.butler.registry.queryDimensions(
+            dimensions,
+            where=query,
+            expand=False)]
+        self.assertEqual(len(result), 1)
+        self.assertEqual(dict(result[0]), expected)
+
+    def testButlerDimensions(self):
+        self. _checkButlerDimension({"instrument"},
+                                    "instrument='notACam'",
+                                    {"instrument": "notACam"})
+        self. _checkButlerDimension({"visit", "instrument"},
+                                    "visit.name='unique_visit'",
+                                    {"instrument": "notACam", "visit": 101})
+        self. _checkButlerDimension({"detector", "instrument"},
+                                    "detector.full_name='chip_5'",
+                                    {"instrument": "notACam", "detector": 5})
+
+    def testDatasets(self):
+        self.assertEqual(len(self.butler.registry.getAllDatasetTypes()), 2)
+
+        # Testing the DatasetType objects is not practical, because all tests need a DimensionUniverse
+        # So just check that we have the dataset types we expect
+        self.butler.registry.getDatasetType("DataType1")
+        self.butler.registry.getDatasetType("DataType2")
+
+        with self.assertRaises(ValueError):
+            makeDatasetType(self.butler, "DataType3", {"4thDimension"}, "NumpyArray")
+        with self.assertRaises(ValueError):
+            makeDatasetType(self.butler, "DataType3", {"instrument"}, "UnstorableType")
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_pipelineTaskTests.py
+++ b/tests/test_pipelineTaskTests.py
@@ -30,7 +30,7 @@ import unittest
 import lsst.utils.tests
 import lsst.daf.butler
 
-from lsst.pipe.base.tests import makeTestButler, makeDatasetType
+from lsst.pipe.base.tests import makeTestButler, makeDatasetType, expandUniqueId
 
 
 class ButlerUtilsTestSuite(lsst.utils.tests.TestCase):
@@ -97,6 +97,21 @@ class ButlerUtilsTestSuite(lsst.utils.tests.TestCase):
             makeDatasetType(self.butler, "DataType3", {"4thDimension"}, "NumpyArray")
         with self.assertRaises(ValueError):
             makeDatasetType(self.butler, "DataType3", {"instrument"}, "UnstorableType")
+
+    def testExpandUniqueId(self):
+        self.assertEqual(dict(expandUniqueId(self.butler, {"instrument": "notACam"})),
+                         {"instrument": "notACam"})
+        self.assertIn(dict(expandUniqueId(self.butler, {"visit": 101})),
+                      [{"instrument": "notACam", "visit": 101},
+                       {"instrument": "dummyCam", "visit": 101}])
+        self.assertIn(dict(expandUniqueId(self.butler, {"detector": 5})),
+                      [{"instrument": "notACam", "detector": 5},
+                       {"instrument": "dummyCam", "detector": 5}])
+        self.assertIn(dict(expandUniqueId(self.butler, {"physical_filter": "k2020"})),
+                      [{"instrument": "notACam", "physical_filter": "k2020"},
+                       {"instrument": "notACam", "physical_filter": "k2020"}])
+        with self.assertRaises(ValueError):
+            expandUniqueId(self.butler, {"tract": 42})
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_pipelineTaskTests.py
+++ b/tests/test_pipelineTaskTests.py
@@ -40,23 +40,12 @@ class ButlerUtilsTestSuite(lsst.utils.tests.TestCase):
         # this has a prohibitive run-time cost at present
         cls.root = tempfile.mkdtemp()
 
-        dataIds = {}
-        dataIds["instrument"] = [{"name": "notACam"}]
-        dataIds["physical_filter"] = [{
-            "name": "k2020",
-            "instrument": "notACam",
-        }]
-        dataIds["visit"] = [{
-            "id": 101,
-            "name": "unique_visit",
-            "instrument": "notACam",
-            "physical_filter": "k2020",
-        }]
-        dataIds["detector"] = [{
-            "id": 5,
-            "full_name": "chip_5",
-            "instrument": "notACam",
-        }]
+        dataIds = {
+            "instrument": ["notACam", "dummyCam"],
+            "physical_filter": ["k2020", "l2019"],
+            "visit": [101, 102],
+            "detector": [5]
+        }
         cls.butler = makeTestButler(cls.root, dataIds)
 
         makeDatasetType(cls.butler, "DataType1", {"instrument"}, "NumpyArray")
@@ -77,18 +66,24 @@ class ButlerUtilsTestSuite(lsst.utils.tests.TestCase):
             where=query,
             expand=False)]
         self.assertEqual(len(result), 1)
-        self.assertEqual(dict(result[0]), expected)
+        self.assertIn(dict(result[0]), expected)
 
     def testButlerDimensions(self):
         self. _checkButlerDimension({"instrument"},
                                     "instrument='notACam'",
-                                    {"instrument": "notACam"})
+                                    [{"instrument": "notACam"}, {"instrument": "dummyCam"}])
         self. _checkButlerDimension({"visit", "instrument"},
-                                    "visit.name='unique_visit'",
-                                    {"instrument": "notACam", "visit": 101})
+                                    "visit=101",
+                                    [{"instrument": "notACam", "visit": 101},
+                                     {"instrument": "dummyCam", "visit": 101}])
+        self. _checkButlerDimension({"visit", "instrument"},
+                                    "visit=102",
+                                    [{"instrument": "notACam", "visit": 102},
+                                     {"instrument": "dummyCam", "visit": 102}])
         self. _checkButlerDimension({"detector", "instrument"},
-                                    "detector.full_name='chip_5'",
-                                    {"instrument": "notACam", "detector": 5})
+                                    "detector=5",
+                                    [{"instrument": "notACam", "detector": 5},
+                                     {"instrument": "dummyCam", "detector": 5}])
 
     def testDatasets(self):
         self.assertEqual(len(self.butler.registry.getAllDatasetTypes()), 2)


### PR DESCRIPTION
This PR adds a module, `lsst.pipe.base.tests`, with test utilities specific to `PipelineTask` subclasses. The intent of these tests is to enable unit testing of:
* whether a task's `Connections` are correctly written and whether they match the inputs and outputs of the `run` method
* any logic in a custom `runQuantum` method
* configuration logic, such as optional or alternative inputs or outputs

Note that, because it depends on a real Butler, the test code has some performance limitations: each call to `makeTestRepo` takes 4-6 seconds on my machine and each call to `makeUniqueButler` takes an extra second.