### PR TITLE
Add text from RFC-183.

### DIFF
--- a/doc/lsst.pipe.base/creating-a-task.rst
+++ b/doc/lsst.pipe.base/creating-a-task.rst
@@ -370,6 +370,7 @@ Variant tasks
 =============
 
 When there are (or are expected to be) different versions of a given task, those tasks should inherit from an abstract base class that defines the interface and is itself a subclass of `lsst.pipe.base.Task`.
-Examples of tasks with multiple variants include star selectors, PSF determiners, etc.
+Star selectors (`lsst.meas.algorithms.BaseStarSelectorTask`) and PSF determiners (`lsst.meas.algorithms.BasePsfDeterminerTask`) are two examples of tasks with multiple variants.
 The abstract base class should be written using `abc.ABC` or `abc.ABCMeta`.
-It should define a registry, using `lsst.pex.config.RegistryField`, and all implementations should register themselves with that registry.
+The same module that defines the abstract base class should also define a registry, using `lsst.pex.config.RegistryField`, and all implementations should register themselves with that registry.
+Examples include `lsst.meas.algorithms.starSelectorRegistry` and `lsst.meas.algorithms.psfDeterminerRegistry`.

--- a/doc/lsst.pipe.base/creating-a-task.rst
+++ b/doc/lsst.pipe.base/creating-a-task.rst
@@ -365,3 +365,11 @@ Otherwise use an `lsst.pex.config.ConfigurableField` to keep config overrides si
 
 For example PSF determiners and star selectors are perhaps best specified using `lsst.pex.config.RegistryField` because there are several variants users may wish to select from.
 However, calibration and instrument signature removal are best specified using  `lsst.pex.config.ConfigurableField`  because (for a given camera) there is likely to be only one logical variant, and that variant is specified in a camera-specific configuration override file, so the user need not specify it.
+
+Variant tasks
+=============
+
+When there are (or are expected to be) different versions of a given task, those tasks should inherit from an abstract base class that defines the interface and is itself a subclass of `lsst.pipe.base.Task`.
+Examples of tasks with multiple variants include star selectors, PSF determiners, etc.
+The abstract base class should be written using `abc.ABC` or `abc.ABCMeta`.
+It should define a registry, using `lsst.pex.config.RegistryField`, and all implementations should register themselves with that registry.


### PR DESCRIPTION
The part about using `RegistryField` for subtasks was, I felt, already covered well enough in the "Subtask" section.