### PR TITLE
DM-23477: Allow ScalarError to be constructed from a single parameter

### DIFF
--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -49,12 +49,19 @@ class ScalarError(TypeError):
     ----------
     key : `str`
         Name of the configuration field for dataset type.
-    numDataIds : `int`
+        If ``numDataIds`` is not specified, it is assumed that this parameter
+        is the full message to be reported and not the key.
+    numDataIds : `int`, optional
         Actual number of DataIds in a Quantum for this dataset type.
     """
-    def __init__(self, key, numDataIds):
-        super().__init__((f"Expected scalar for output dataset field {key}, "
-                          f"received {numDataIds} DataIds"))
+    def __init__(self, key, numDataIds=None):
+        if numDataIds is None:
+            # Assume we are receiving a normal TypeError message
+            err_msg = key
+        else:
+            err_msg = f"Expected scalar for output dataset field {key}, " \
+                f"received {numDataIds} DataIds"
+        super().__init__(err_msg)
 
 
 class PipelineTaskConnectionDict(UserDict):


### PR DESCRIPTION
When this class is used in multiprocessing environment ScalarError
must be pickled. When being pickled only the single string passed
to TypeError is serialized. This leads to an initialization error
when the object is recreated and breaks error reporting.

Change things so that a single parameter acts like any other
standard exception.