### PR TITLE
DM-23616: Run converted ap_verify testdata through gen3 pipeline

### DIFF
--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -74,7 +74,7 @@ If you do need `~lsst.pipe.base.PipelineTask.runQuantum` to call `~lsst.pipe.bas
    butler = butlerTests.makeTestCollection(repo)
    task = AwesomeTask()
    quantum = testUtils.makeQuantum(
-       task, butler,
+       task, butler, dataId,
        {key: dataId for key in {"input", "output"}})
    run = testUtils.runTestQuantum(task, butler, quantum)
    # Actual input dataset omitted for simplicity

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -140,7 +140,14 @@ def _refFromConnection(butler, connection, dataId, **kwargs):
     """
     universe = butler.registry.dimensions
     dataId = DataCoordinate.standardize(dataId, **kwargs, universe=universe)
-    datasetType = connection.makeDatasetType(universe)
+
+    # skypix is a PipelineTask alias for "some spatial index", Butler doesn't
+    # understand it. Code copied from TaskDatasetTypes.fromTaskDef
+    if "skypix" in connection.dimensions:
+        datasetType = butler.registry.getDatasetType(connection.name)
+    else:
+        datasetType = connection.makeDatasetType(universe)
+
     try:
         butler.registry.getDatasetType(datasetType.name)
     except KeyError:

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -24,6 +24,7 @@ __all__ = ["makeQuantum", "runTestQuantum", "assertValidOutput"]
 
 
 import collections.abc
+import itertools
 import unittest.mock
 
 from lsst.daf.butler import DataCoordinate, DatasetRef, Quantum, StorageClassFactory
@@ -52,7 +53,7 @@ def makeQuantum(task, butler, dataIds):
     connections = task.config.ConnectionsClass(config=task.config)
 
     try:
-        for name in connections.inputs:
+        for name in itertools.chain(connections.inputs, connections.prerequisiteInputs):
             connection = connections.__getattribute__(name)
             _checkDataIdMultiplicity(name, dataIds[name], connection.multiple)
             ids = _normalizeDataIds(dataIds[name])

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -70,7 +70,7 @@ class PatchConnections(PipelineTaskConnections, dimensions={"skymap", "tract"}):
         multiple=True,
         dimensions={"skymap", "tract", "patch"},
     )
-    b = connectionTypes.Input(
+    b = connectionTypes.PrerequisiteInput(
         name="PatchB",
         storageClass="StructuredData",
         multiple=False,
@@ -87,7 +87,7 @@ class PatchConnections(PipelineTaskConnections, dimensions={"skymap", "tract"}):
         super().__init__(config=config)
 
         if not config.doUseB:
-            self.inputs.remove("b")
+            self.prerequisiteInputs.remove("b")
 
 
 class VisitConfig(PipelineTaskConfig, pipelineConnections=VisitConnections):

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -246,7 +246,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {key: dataId for key in {"a", "b", "outA", "outB"}})
+            makeQuantum(task, self.butler, dataId, {key: dataId for key in {"a", "b", "outA", "outB"}})
 
     def testMakeQuantumInvalidDimension(self):
         config = VisitConfig()
@@ -262,7 +262,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self.butler.put(butlerTests.MetricsExample(data=inB), "VisitB", dataIdV)
 
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {
+            makeQuantum(task, self.butler, dataIdV, {
                 "a": dataIdP,
                 "b": dataIdV,
                 "outA": dataIdV,
@@ -276,7 +276,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self._makePatchTestData(dataId)
 
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {
+            makeQuantum(task, self.butler, dataId, {
                 "a": dict(dataId, patch=0),
                 "b": dataId,
                 "out": [dict(dataId, patch=patch) for patch in {0, 1}],
@@ -289,7 +289,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self._makePatchTestData(dataId)
 
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {
+            makeQuantum(task, self.butler, dataId, {
                 "a": [dict(dataId, patch=patch) for patch in {0, 1}],
                 "b": [dataId],
                 "out": [dict(dataId, patch=patch) for patch in {0, 1}],
@@ -302,9 +302,9 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {key: dataId for key in {"a", "outA", "outB"}})
+            makeQuantum(task, self.butler, dataId, {key: dataId for key in {"a", "outA", "outB"}})
         with self.assertRaises(ValueError):
-            makeQuantum(task, self.butler, {key: dataId for key in {"a", "b", "outB"}})
+            makeQuantum(task, self.butler, dataId, {key: dataId for key in {"a", "b", "outB"}})
 
     def testMakeQuantumCorruptedDataId(self):
         task = VisitTask()
@@ -313,8 +313,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
-            # third argument should be a mapping keyed by component name
-            makeQuantum(task, self.butler, dataId)
+            # fourth argument should be a mapping keyed by component name
+            makeQuantum(task, self.butler, dataId, dataId)
 
     def testRunTestQuantumVisitWithRun(self):
         task = VisitTask()
@@ -322,7 +322,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
         data = self._makeVisitTestData(dataId)
 
-        quantum = makeQuantum(task, self.butler, {key: dataId for key in {"a", "b", "outA", "outB"}})
+        quantum = makeQuantum(task, self.butler, dataId,
+                              {key: dataId for key in {"a", "b", "outA", "outB"}})
         runTestQuantum(task, self.butler, quantum, mockRun=False)
 
         # Can we use runTestQuantum to verify that task.run got called with correct inputs/outputs?
@@ -339,7 +340,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
         data = self._makePatchTestData(dataId)
 
-        quantum = makeQuantum(task, self.butler, {
+        quantum = makeQuantum(task, self.butler, dataId, {
             "a": [dataset[0] for dataset in data["PatchA"]],
             "b": dataId,
             "out": [dataset[0] for dataset in data["PatchA"]],
@@ -360,7 +361,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
         data = self._makeVisitTestData(dataId)
 
-        quantum = makeQuantum(task, self.butler, {key: dataId for key in {"a", "b", "outA", "outB"}})
+        quantum = makeQuantum(task, self.butler, dataId,
+                              {key: dataId for key in {"a", "b", "outA", "outB"}})
         run = runTestQuantum(task, self.butler, quantum, mockRun=True)
 
         # Can we use the mock to verify that task.run got called with the correct inputs?
@@ -373,7 +375,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
         data = self._makePatchTestData(dataId)
 
-        quantum = makeQuantum(task, self.butler, {
+        quantum = makeQuantum(task, self.butler, dataId, {
             # Use lists, not sets, to ensure order agrees with test assertion
             "a": [dataset[0] for dataset in data["PatchA"]],
             "b": dataId,
@@ -395,7 +397,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
         data = self._makePatchTestData(dataId)
 
-        quantum = makeQuantum(task, self.butler, {
+        quantum = makeQuantum(task, self.butler, dataId, {
             # Use lists, not sets, to ensure order agrees with test assertion
             "a": [dataset[0] for dataset in data["PatchA"]],
             "out": [dataset[0] for dataset in data["PatchA"]],
@@ -466,7 +468,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         data = butlerTests.MetricsExample(data=[1, 2, 3])
         self.butler.put(data, "PixA", dataId)
 
-        quantum = makeQuantum(task, self.butler, {key: dataId for key in {"a", "out"}})
+        quantum = makeQuantum(task, self.butler, dataId, {key: dataId for key in {"a", "out"}})
         run = runTestQuantum(task, self.butler, quantum, mockRun=True)
 
         # PixA dataset should have been retrieved by runTestQuantum


### PR DESCRIPTION
This PR fixes bugs and missing features in the PipelineTask test framework (`pipe.base.testUtils`) in response to trying to apply it to `CalibrateTask` on lsst/pipe_tasks#362.