### PR TITLE
DM-25776: Adapt to daf.butler.DataCoordinate API change.

### DIFF
--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -32,10 +32,10 @@ from typing import Callable, Iterable, Optional
 
 from lsst.daf.butler import (
     CollectionSearch,
+    DataCoordinate,
     DatasetRef,
     DatasetType,
     DimensionUniverse,
-    ExpandedDataCoordinate,
     Registry,
 )
 
@@ -185,7 +185,7 @@ class PrerequisiteInput(BaseInput):
         passed to it. If no function is specified, the default temporal spatial
         lookup will be used.
     """
-    lookupFunction: Optional[Callable[[DatasetType, Registry, ExpandedDataCoordinate, CollectionSearch],
+    lookupFunction: Optional[Callable[[DatasetType, Registry, DataCoordinate, CollectionSearch],
                                       Iterable[DatasetRef]]] = None
 
 

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -46,7 +46,6 @@ from lsst.daf.butler import (
     DatasetType,
     DimensionGraph,
     DimensionUniverse,
-    ExpandedDataCoordinate,
     NamedKeyDict,
     Quantum,
 )
@@ -499,7 +498,7 @@ class _PipelineScaffolding:
         """
         _LOG.debug("Building query for data IDs.")
         # Initialization datasets always have empty data IDs.
-        emptyDataId = ExpandedDataCoordinate(registry.dimensions.empty, (), records={})
+        emptyDataId = DataCoordinate.makeEmpty(registry.dimensions)
         for datasetType, refs in itertools.chain(self.initInputs.items(),
                                                  self.initIntermediates.items(),
                                                  self.initOutputs.items()):


### PR DESCRIPTION
DataCoordinate is now an ABC, but has a method for creating an empty one.