### PR TITLE
DM-26015 Add dimension validation

### DIFF
--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -113,6 +113,13 @@ class DimensionedConnection(BaseConnection):
     """
     dimensions: typing.Iterable[str] = ()
 
+    def __post_init__(self):
+        if isinstance(self.dimensions, str):
+            raise TypeError("Dimensions must be iterable of dimensions, got str,"
+                            "possibly omitted trailing comma")
+        if not isinstance(self.dimensions, typing.Iterable):
+            raise TypeError("Dimensions must be iterable of dimensions")
+
     def makeDatasetType(self, universe: DimensionUniverse):
         """Construct a true `DatasetType` instance with normalized dimensions.
         Parameters

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -121,6 +121,11 @@ class PipelineTaskConnectionsMetaclass(type):
                 if 'dimensions' not in kwargs:
                     raise dimensionsValueError
             try:
+                if isinstance(kwargs['dimensions'], str):
+                    raise TypeError("Dimensions must be iterable of dimensions, got str,"
+                                    "possibly omitted trailing comma")
+                if not isinstance(kwargs['dimensions'], typing.Iterable):
+                    raise TypeError("Dimensions must be iterable of dimensions")
                 dct['dimensions'] = set(kwargs['dimensions'])
             except TypeError as exc:
                 raise dimensionsValueError from exc

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -149,6 +149,23 @@ class TestConnectionsClass(unittest.TestCase):
         with self.assertRaises(ValueError):
             connections.adjustQuantum(inputRefs)
 
+    def testDimensionCheck(self):
+        with self.assertRaises(TypeError):
+            class TestConnectionsWithBrokenDimensionsStr(pipeBase.PipelineTask, dimensions=("a")):
+                pass
+
+        with self.assertRaises(TypeError):
+            class TestConnectionsWithBrokenDimensionsIter(pipeBase.PipelineTask, dimensions=2):
+                pass
+
+        with self.assertRaises(TypeError):
+            pipeBase.connectionTypes.Output(Doc="mock doc", dimensions=("a"), name="output",
+                                            storageClass="mock")
+
+        with self.assertRaises(TypeError):
+            pipeBase.connectionTypes.Output(Doc="mock doc", dimensions=1, name="output",
+                                            storageClass="mock")
+
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     pass


### PR DESCRIPTION
Validate that dimensions specified in a connection or PipelineTask
declaration are not strings and are iterable.