### PR TITLE
DM-26144 Inherit configs when inheriting a Pipeline

### DIFF
--- a/python/lsst/pipe/base/pipeline.py
+++ b/python/lsst/pipe/base/pipeline.py
@@ -33,6 +33,7 @@ from types import MappingProxyType
 from typing import Mapping, Union, Generator, TYPE_CHECKING
 
 import copy
+import os
 
 # -----------------------------
 #  Imports for other modules --
@@ -335,7 +336,7 @@ class Pipeline:
                     if configIR.dataId is None:
                         if configIR.file:
                             for configFile in configIR.file:
-                                overrides.addFileOverride(configFile)
+                                overrides.addFileOverride(os.path.expandvars(configFile))
                         if configIR.python is not None:
                             overrides.addPythonOverride(configIR.python)
                         for key, value in configIR.rest.items():

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -380,7 +380,18 @@ class PipelineIR:
                                  "be unique")
             accumulate_tasks.update(tmp_IR.tasks)
             self.contracts.extend(tmp_IR.contracts)
-        accumulate_tasks.update(self.tasks)
+
+        # merge the dict of label:TaskIR objects, preserving any configs in the
+        # imported pipeline if the labels point to the same class
+        for label, task in self.tasks.items():
+            if label not in accumulate_tasks:
+                accumulate_tasks[label] = task
+            elif accumulate_tasks[label].klass == task.klass:
+                if task.config is not None:
+                    for config in task.config:
+                        accumulate_tasks[label].add_or_update_config(config)
+            else:
+                accumulate_tasks[label] = task
         self.tasks = accumulate_tasks
 
     def _read_tasks(self, loaded_yaml):

--- a/tests/testPipeline2.yaml
+++ b/tests/testPipeline2.yaml
@@ -1,3 +1,6 @@
 description: Test Pipeline
 tasks:
-  modA: "test.moduleA"
+  modA:
+      class: "test.moduleA"
+      config:
+          value1: 1

--- a/tests/test_pipelineIR.py
+++ b/tests/test_pipelineIR.py
@@ -191,6 +191,36 @@ class PipelineIRTestCase(unittest.TestCase):
         pipeline = PipelineIR.from_string(pipeline_str)
         self.assertEqual(pipeline.contracts, [])
 
+        # Test that configs are inherited when defining the same task again with
+        # the same label
+        pipeline_str = textwrap.dedent("""
+        description: Test Pipeline
+        inherits:
+            - $PIPE_BASE_DIR/tests/testPipeline2.yaml
+        tasks:
+          modA:
+            class: "test.moduleA"
+            config:
+                value2: 2
+        """)
+        pipeline = PipelineIR.from_string(pipeline_str)
+        self.assertEqual(pipeline.tasks["modA"].config[0].rest, {"value1": 1, "value2": 2})
+
+        # Test that configs are not inherited when redefining the task
+        # associated with a label
+        pipeline_str = textwrap.dedent("""
+        description: Test Pipeline
+        inherits:
+            - $PIPE_BASE_DIR/tests/testPipeline2.yaml
+        tasks:
+          modA:
+            class: "test.moduleAReplace"
+            config:
+                value2: 2
+        """)
+        pipeline = PipelineIR.from_string(pipeline_str)
+        self.assertEqual(pipeline.tasks["modA"].config[0].rest, {"value2": 2})
+
     def testReadContracts(self):
         # Verify that contracts are read in from a pipeline
         location = os.path.expandvars("$PIPE_BASE_DIR/tests/testPipeline1.yaml")

--- a/tests/test_pipelineIR.py
+++ b/tests/test_pipelineIR.py
@@ -68,7 +68,7 @@ class ConfigIRTestCase(unittest.TestCase):
         self.assertEqual(config5.rest, {"f": 5, "g": 6, "h": 7, "i": 8})
 
         # Cant merge configs with shared keys
-        self.assertEqual(list(config5.maybe_merge(config7)), [config5, config7])
+        self.assertEqual(list(config6.maybe_merge(config7)), [config6, config7])
 
 
 class PipelineIRTestCase(unittest.TestCase):


### PR DESCRIPTION
If a Pipeline is inherited that matches a label with the same task current Pipeline, inherit the configs for that label. Otherwise only use the definition from the current Pipeline.

Second commit:
Because I was in pipe_base anyway, a second commit adds the ability to specify a config file path that includes shell variables. These variables will be expanded when a Pipeline is converted to an expanded Pipeline.