### PR TITLE
DM-21919: Run ap_verify end-to-end in Gen 3

### DIFF
--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -366,6 +366,7 @@ class PipelineTaskConnections(metaclass=PipelineTaskConnectionsMetaclass):
         self.outputs = set(self.outputs)
         self.initInputs = set(self.initInputs)
         self.initOutputs = set(self.initOutputs)
+        self.allConnections = dict(self.allConnections)
 
         if config is None or not isinstance(config, configMod.PipelineTaskConfig):
             raise ValueError("PipelineTaskConnections must be instantiated with"

--- a/python/lsst/pipe/base/pipeline.py
+++ b/python/lsst/pipe/base/pipeline.py
@@ -516,10 +516,10 @@ class TaskDatasetTypes:
         # optionally add output dataset for metadata
         outputs = makeDatasetTypesSet("outputs", freeze=False)
         if taskDef.metadataDatasetName is not None:
-            # Metadata is supposed to be of the PropertyList type, its dimensions
+            # Metadata is supposed to be of the PropertySet type, its dimensions
             # correspond to a task quantum
             dimensions = registry.dimensions.extract(taskDef.connections.dimensions)
-            outputs |= {DatasetType(taskDef.metadataDatasetName, dimensions, "PropertyList")}
+            outputs |= {DatasetType(taskDef.metadataDatasetName, dimensions, "PropertySet")}
         outputs.freeze()
 
         return cls(


### PR DESCRIPTION
This PR modifies the Gen 3 storage class for task metadata to be `PropertySet` rather than `PropertyList`. This allows storage of more complex metadata objects than previously possible.