### PR TITLE
DM-27060: pipe_base documentation fails to build due to BuildId

### DIFF
--- a/doc/lsst.pipe.base/index.rst
+++ b/doc/lsst.pipe.base/index.rst
@@ -70,6 +70,8 @@ Python API reference
 
 .. automodapi:: lsst.pipe.base
    :no-main-docstr:
+   :skip: BuildId
+   :skip: DatasetTypeName
 
 .. automodapi:: lsst.pipe.base.testUtils
    :no-main-docstr:


### PR DESCRIPTION
These types cause a documentation build failure:

  FileNotFoundError: [Errno 2] No such file or directory: '/j/ws/sqre/infra/documenteer/doc_template/_build/doctree/py-api/lsst.pipe.base.BuildId.doctree'

Presumably because Sphinx/autodoc doesn't understand that they are generated
by typing.NewType rather than being fully-fledged classes.