### PR TITLE
DM-27131: Reorganize pickling to allow subclasses to add parameters

### DIFF
--- a/examples/argumentParser.py
+++ b/examples/argumentParser.py
@@ -22,13 +22,14 @@
 #
 """Example showing use of the argument parser
 
-Here are some examples that use the repository in obs_test (which is automatically setup
-when pipe_base is setup):
+Here are some examples that use the repository in obs_test (which is
+automatically setup when pipe_base is setup):
 
 ./argumentParser.py $OBS_TEST_DIR/data/input --help
 ./argumentParser.py $OBS_TEST_DIR/data/input --id --show config data
 ./argumentParser.py $OBS_TEST_DIR/data/input --id filter=g --show data
-./argumentParser.py $OBS_TEST_DIR/data/input --id filter=g --config oneFloat=1.5 --show config
+./argumentParser.py $OBS_TEST_DIR/data/input --id filter=g \
+    --config oneFloat=1.5 --show config
 """
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase

--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -157,7 +157,8 @@ class DataIdContainer:
                 try:
                     keyType = idKeyTypeDict[key]
                 except KeyError:
-                    # OK, assume that it's a valid key and guess that it's a string
+                    # OK, assume that it's a valid key and guess that it's a
+                    # string
                     keyType = str
 
                     log = lsstLog.Log.getDefaultLogger()
@@ -735,7 +736,8 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c 
         mapperClass = dafPersist.Butler.getMapperClass(_fixPath(DEFAULT_INPUT_NAME, namespace.rawInput))
         namespace.calib = _fixPath(DEFAULT_CALIB_NAME, namespace.rawCalib)
 
-        # If an output directory is specified, process it and assign it to the namespace
+        # If an output directory is specified, process it and assign it to the
+        # namespace
         if namespace.rawOutput:
             namespace.output = _fixPath(DEFAULT_OUTPUT_NAME, namespace.rawOutput)
         else:
@@ -850,7 +852,8 @@ log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c 
             Namespace (an ) with the following fields:
 
             - ``camera``: the camera name.
-            - ``config``: the config passed to parse_args, with no overrides applied.
+            - ``config``: the config passed to parse_args, with no overrides
+              applied.
             - ``obsPkg``: the ``obs_`` package for this camera.
             - ``log``: a `lsst.log` Log.
 
@@ -1009,7 +1012,8 @@ def obeyShowArgument(showOpts, config=None, exit=False):
                     """
 
                     def __init__(self, pattern):
-                        # obey case if pattern isn't lowecase or requests NOIGNORECASE
+                        # obey case if pattern isn't lowecase or requests
+                        # NOIGNORECASE
                         mat = re.search(r"(.*):NOIGNORECASE$", pattern)
 
                         if mat:

--- a/python/lsst/pipe/base/butlerQuantumContext.py
+++ b/python/lsst/pipe/base/butlerQuantumContext.py
@@ -108,28 +108,32 @@ class ButlerQuantumContext:
         Parameters
         ----------
         dataset
-            This argument may either be an `InputQuantizedConnection` which describes
-            all the inputs of a quantum, a list of `~lsst.daf.butler.DatasetRef`, or
-            a single `~lsst.daf.butler.DatasetRef`. The function will get and return
+            This argument may either be an `InputQuantizedConnection` which
+            describes all the inputs of a quantum, a list of
+            `~lsst.daf.butler.DatasetRef`, or a single
+            `~lsst.daf.butler.DatasetRef`. The function will get and return
             the corresponding datasets from the butler.
 
         Returns
         -------
         return : `object`
-            This function returns arbitrary objects fetched from the bulter. The
-            structure these objects are returned in depends on the type of the input
-            argument. If the input dataset argument is a InputQuantizedConnection, then
-            the return type will be a dictionary with keys corresponding to the attributes
-            of the `InputQuantizedConnection` (which in turn are the attribute identifiers
-            of the connections). If the input argument is of type `list` of
-            `~lsst.daf.butler.DatasetRef` then the return type  will be a list of objects.
-            If the input argument is a single `~lsst.daf.butler.DatasetRef` then a single
-            object will be returned.
+            This function returns arbitrary objects fetched from the bulter.
+            The structure these objects are returned in depends on the type of
+            the input argument. If the input dataset argument is a
+            `InputQuantizedConnection`, then the return type will be a
+            dictionary with keys corresponding to the attributes of the
+            `InputQuantizedConnection` (which in turn are the attribute
+            identifiers of the connections). If the input argument is of type
+            `list` of `~lsst.daf.butler.DatasetRef` then the return type will
+            be a list of objects.  If the input argument is a single
+            `~lsst.daf.butler.DatasetRef` then a single object will be
+            returned.
 
         Raises
         ------
         ValueError
-            If a `DatasetRef` is passed to get that is not defined in the quantum object
+            Raised if a `DatasetRef` is passed to get that is not defined in
+            the quantum object
         """
         if isinstance(dataset, InputQuantizedConnection):
             retVal = {}
@@ -154,26 +158,30 @@ class ButlerQuantumContext:
         Parameters
         ----------
         values : `Struct` or `list` of `object` or `object`
-            The data that should be put with the butler. If the type of the dataset
-            is `OutputQuantizedConnection` then this argument should be a `Struct`
-            with corresponding attribute names. Each attribute should then correspond
-            to either a list of object or a single object depending of the type of the
-            corresponding attribute on dataset. I.e. if dataset.calexp is [datasetRef1,
-            datasetRef2] then values.calexp should be [calexp1, calexp2]. Like wise
-            if there is a single ref, then only a single object need be passed. The same
-            restriction applies if dataset is directly a `list` of `DatasetRef` or a
-            single `DatasetRef`.
+            The data that should be put with the butler. If the type of the
+            dataset is `OutputQuantizedConnection` then this argument should be
+            a `Struct` with corresponding attribute names. Each attribute
+            should then correspond to either a list of object or a single
+            object depending of the type of the corresponding attribute on
+            dataset. I.e. if ``dataset.calexp`` is
+            ``[datasetRef1, datasetRef2]`` then ``values.calexp`` should be
+            ``[calexp1, calexp2]``. Like wise if there is a single ref, then
+            only a single object need be passed. The same restriction applies
+            if dataset is directly a `list` of `DatasetRef` or a single
+            `DatasetRef`.
         dataset
-            This argument may either be an `InputQuantizedConnection` which describes
-            all the inputs of a quantum, a list of `lsst.daf.butler.DatasetRef`, or
-            a single `lsst.daf.butler.DatasetRef`. The function will get and return
+            This argument may either be an `InputQuantizedConnection` which
+            describes all the inputs of a quantum, a list of
+            `lsst.daf.butler.DatasetRef`, or a single
+            `lsst.daf.butler.DatasetRef`. The function will get and return
             the corresponding datasets from the butler.
 
         Raises
         ------
         ValueError
-            If a `DatasetRef` is passed to put that is not defined in the quantum object, or
-            the type of values does not match what is expected from the type of dataset.
+            Raised if a `DatasetRef` is passed to put that is not defined in
+            the quantum object, or the type of values does not match what is
+            expected from the type of dataset.
         """
         if isinstance(dataset, OutputQuantizedConnection):
             if not isinstance(values, Struct):
@@ -199,19 +207,20 @@ class ButlerQuantumContext:
             raise TypeError("Dataset argument is not a type that can be used to put")
 
     def _checkMembership(self, ref: typing.Union[typing.List[DatasetRef], DatasetRef], inout: set):
-        """Internal function used to check if a DatasetRef is part of the input quantum
+        """Internal function used to check if a DatasetRef is part of the input
+        quantum
 
-        This function will raise an exception if the ButlerQuantumContext is used to
-        get/put a DatasetRef which is not defined in the quantum.
+        This function will raise an exception if the ButlerQuantumContext is
+        used to get/put a DatasetRef which is not defined in the quantum.
 
         Parameters
         ----------
         ref : `list` of `DatasetRef` or `DatasetRef`
             Either a list or a single `DatasetRef` to check
         inout : `set`
-            The connection type to check, e.g. either an input or an output. This prevents
-            both types needing to be checked for every operation, which may be important
-            for Quanta with lots of `DatasetRef`s.
+            The connection type to check, e.g. either an input or an output.
+            This prevents both types needing to be checked for every operation,
+            which may be important for Quanta with lots of `DatasetRef`.
         """
         if not isinstance(ref, list):
             ref = [ref]

--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -39,7 +39,8 @@ from lsst.log import Log
 def _runPool(pool, timeout, function, iterable):
     """Wrapper around ``pool.map_async``, to handle timeout
 
-    This is required so as to trigger an immediate interrupt on the KeyboardInterrupt (Ctrl-C); see
+    This is required so as to trigger an immediate interrupt on the
+    KeyboardInterrupt (Ctrl-C); see
     http://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
     """
     return pool.map_async(function, iterable).get(timeout)
@@ -53,20 +54,26 @@ def profile(filename, log=None):
     Parameters
     ----------
     filename : `str`
-        Filename to which to write profile (profiling disabled if `None` or empty).
+        Filename to which to write profile (profiling disabled if `None` or
+        empty).
     log : `lsst.log.Log`, optional
         Log object for logging the profile operations.
 
-    If profiling is enabled, the context manager returns the cProfile.Profile object (otherwise
-    it returns None), which allows additional control over profiling.  You can obtain this using
-    the "as" clause, e.g.:
+    If profiling is enabled, the context manager returns the cProfile.Profile
+    object (otherwise it returns None), which allows additional control over
+    profiling.  You can obtain this using the "as" clause, e.g.:
+
+    .. code-block:: python
 
         with profile(filename) as prof:
             runYourCodeHere()
 
-    The output cumulative profile can be printed with a command-line like::
+    The output cumulative profile can be printed with a command-line like:
 
-        python -c 'import pstats; pstats.Stats("<filename>").sort_stats("cumtime").print_stats(30)'
+    .. code-block:: bash
+
+        python -c 'import pstats; \
+            pstats.Stats("<filename>").sort_stats("cumtime").print_stats(30)'
     """
     if not filename:
         # Nothing to do
@@ -92,61 +99,73 @@ class TaskRunner:
     TaskClass : `lsst.pipe.base.Task` subclass
         The class of the task to run.
     parsedCmd : `argparse.Namespace`
-        The parsed command-line arguments, as returned by the task's argument parser's
-        `~lsst.pipe.base.ArgumentParser.parse_args` method.
+        The parsed command-line arguments, as returned by the task's argument
+        parser's `~lsst.pipe.base.ArgumentParser.parse_args` method.
 
         .. warning::
 
-           Do not store ``parsedCmd``, as this instance is pickled (if multiprocessing) and parsedCmd may
-           contain non-picklable elements. It certainly contains more data than we need to send to each
+           Do not store ``parsedCmd``, as this instance is pickled (if
+           multiprocessing) and parsedCmd may contain non-picklable elements.
+           It certainly contains more data than we need to send to each
            instance of the task.
     doReturnResults : `bool`, optional
-        Should run return the collected result from each invocation of the task? This is only intended for
-        unit tests and similar use. It can easily exhaust memory (if the task returns enough data and you
-        call it enough times) and it will fail when using multiprocessing if the returned data cannot be
-        pickled.
+        Should run return the collected result from each invocation of the
+        task? This is only intended for unit tests and similar use. It can
+        easily exhaust memory (if the task returns enough data and you call it
+        enough times) and it will fail when using multiprocessing if the
+        returned data cannot be pickled.
 
-        Note that even if ``doReturnResults`` is False a struct with a single member "exitStatus" is returned,
-        with value 0 or 1 to be returned to the unix shell.
+        Note that even if ``doReturnResults`` is False a struct with a single
+        member "exitStatus" is returned, with value 0 or 1 to be returned to
+        the unix shell.
 
     Raises
     ------
     ImportError
-        If multiprocessing is requested (and the task supports it) but the multiprocessing library cannot be
-        imported.
+        Raised if multiprocessing is requested (and the task supports it) but
+        the multiprocessing library cannot be imported.
 
     Notes
     -----
-    Each command-line task (subclass of `lsst.pipe.base.CmdLineTask`) has a task runner. By default it is this
-    class, but some tasks require a subclass. See the manual :ref:`creating-a-command-line-task` for more
-    information. See `CmdLineTask.parseAndRun` to see how a task runner is used.
+    Each command-line task (subclass of `lsst.pipe.base.CmdLineTask`) has a
+    task runner. By default it is this class, but some tasks require a
+    subclass. See the manual :ref:`creating-a-command-line-task` for more
+    information. See `CmdLineTask.parseAndRun` to see how a task runner is
+    used.
 
-    You may use this task runner for your command-line task if your task has a runDataRef method that takes
-    exactly one argument: a butler data reference. Otherwise you must provide a task-specific subclass of
-    this runner for your task's ``RunnerClass`` that overrides `TaskRunner.getTargetList` and possibly
+    You may use this task runner for your command-line task if your task has a
+    ``runDataRef`` method that takes exactly one argument: a butler data
+    reference. Otherwise you must provide a task-specific subclass of
+    this runner for your task's ``RunnerClass`` that overrides
+    `TaskRunner.getTargetList` and possibly
     `TaskRunner.__call__`. See `TaskRunner.getTargetList` for details.
 
-    This design matches the common pattern for command-line tasks: the runDataRef method takes a single data
-    reference, of some suitable name. Additional arguments are rare, and if present, require a subclass of
+    This design matches the common pattern for command-line tasks: the
+    ``runDataRef`` method takes a single data reference, of some suitable name.
+    Additional arguments are rare, and if present, require a subclass of
     `TaskRunner` that calls these additional arguments by name.
 
-    Instances of this class must be picklable in order to be compatible with multiprocessing. If
-    multiprocessing is requested (``parsedCmd.numProcesses > 1``) then `runDataRef` calls
-    `prepareForMultiProcessing` to jettison optional non-picklable elements. If your task runner is not
-    compatible with multiprocessing then indicate this in your task by setting class variable
-    ``canMultiprocess=False``.
+    Instances of this class must be picklable in order to be compatible with
+    multiprocessing. If multiprocessing is requested
+    (``parsedCmd.numProcesses > 1``) then `runDataRef` calls
+    `prepareForMultiProcessing` to jettison optional non-picklable elements.
+    If your task runner is not compatible with multiprocessing then indicate
+    this in your task by setting class variable ``canMultiprocess=False``.
 
-    Due to a `python bug`__, handling a `KeyboardInterrupt` properly `requires specifying a timeout`__. This
-    timeout (in sec) can be specified as the ``timeout`` element in the output from
-    `~lsst.pipe.base.ArgumentParser` (the ``parsedCmd``), if available, otherwise we use `TaskRunner.TIMEOUT`.
+    Due to a `python bug`__, handling a `KeyboardInterrupt` properly `requires
+    specifying a timeout`__. This timeout (in sec) can be specified as the
+    ``timeout`` element in the output from `~lsst.pipe.base.ArgumentParser`
+    (the ``parsedCmd``), if available, otherwise we use `TaskRunner.TIMEOUT`.
 
-    By default, we disable "implicit" threading -- ie, as provided by underlying numerical libraries such as
-    MKL or BLAS. This is designed to avoid thread contention both when a single command line task spawns
-    multiple processes and when multiple users are running on a shared system. Users can override this
-    behaviour by setting the ``LSST_ALLOW_IMPLICIT_THREADS`` environment variable.
+    By default, we disable "implicit" threading -- ie, as provided by
+    underlying numerical libraries such as MKL or BLAS. This is designed to
+    avoid thread contention both when a single command line task spawns
+    multiple processes and when multiple users are running on a shared system.
+    Users can override this behaviour by setting the
+    ``LSST_ALLOW_IMPLICIT_THREADS`` environment variable.
 
     .. __: http://bugs.python.org/issue8296
-    .. __:  http://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
+    .. __: http://stackoverflow.com/questions/1408356/
     """
 
     TIMEOUT = 3600*24*30
@@ -191,14 +210,15 @@ class TaskRunner:
         Returns
         -------
         resultList : `list`
-            A list of results returned by `TaskRunner.__call__`, or an empty list if `TaskRunner.__call__`
-            is not called (e.g. if `TaskRunner.precall` returns `False`). See `TaskRunner.__call__`
+            A list of results returned by `TaskRunner.__call__`, or an empty
+            list if `TaskRunner.__call__` is not called (e.g. if
+            `TaskRunner.precall` returns `False`). See `TaskRunner.__call__`
             for details.
 
         Notes
         -----
-        The task is run under multiprocessing if `TaskRunner.numProcesses` is more than 1; otherwise
-        processing is serial.
+        The task is run under multiprocessing if `TaskRunner.numProcesses`
+        is more than 1; otherwise processing is serial.
         """
         resultList = []
         disableImplicitThreading()  # To prevent thread contention
@@ -236,27 +256,36 @@ class TaskRunner:
         Parameters
         ----------
         parsedCmd : `argparse.Namespace`
-            The parsed command object returned by `lsst.pipe.base.argumentParser.ArgumentParser.parse_args`.
+            The parsed command object returned by
+            `lsst.pipe.base.argumentParser.ArgumentParser.parse_args`.
         kwargs
-            Any additional keyword arguments. In the default `TaskRunner` this is an empty dict, but having
-            it simplifies overriding `TaskRunner` for tasks whose runDataRef method takes additional arguments
+            Any additional keyword arguments. In the default `TaskRunner` this
+            is an empty dict, but having it simplifies overriding `TaskRunner`
+            for tasks whose runDataRef method takes additional arguments
             (see case (1) below).
 
         Notes
         -----
-        The default implementation of `TaskRunner.getTargetList` and `TaskRunner.__call__` works for any
-        command-line task whose runDataRef method takes exactly one argument: a data reference. Otherwise you
-        must provide a variant of TaskRunner that overrides `TaskRunner.getTargetList` and possibly
-        `TaskRunner.__call__`. There are two cases.
+        The default implementation of `TaskRunner.getTargetList` and
+        `TaskRunner.__call__` works for any command-line task whose
+        ``runDataRef`` method takes exactly one argument: a data reference.
+        Otherwise you must provide a variant of TaskRunner that overrides
+        `TaskRunner.getTargetList` and possibly `TaskRunner.__call__`.
+        There are two cases.
 
         **Case 1**
 
-        If your command-line task has a ``runDataRef`` method that takes one data reference followed by
-        additional arguments, then you need only override `TaskRunner.getTargetList` to return the additional
-        arguments as an argument dict. To make this easier, your overridden version of
-        `~TaskRunner.getTargetList` may call `TaskRunner.getTargetList` with the extra arguments as keyword
-        arguments. For example, the following adds an argument dict containing a single key: "calExpList",
-        whose value is the list of data IDs for the calexp ID argument::
+        If your command-line task has a ``runDataRef`` method that takes one
+        data reference followed by additional arguments, then you need only
+        override `TaskRunner.getTargetList` to return the additional
+        arguments as an argument dict. To make this easier, your overridden
+        version of `~TaskRunner.getTargetList` may call
+        `TaskRunner.getTargetList` with the extra arguments as keyword
+        arguments. For example, the following adds an argument dict containing
+        a single key: "calExpList", whose value is the list of data IDs for
+        the calexp ID argument:
+
+        .. code-block:: python
 
             def getTargetList(parsedCmd):
                 return TaskRunner.getTargetList(
@@ -264,7 +293,9 @@ class TaskRunner:
                     calExpList=parsedCmd.calexp.idList
                 )
 
-        It is equivalent to this slightly longer version::
+        It is equivalent to this slightly longer version:
+
+        .. code-block:: python
 
             @staticmethod
             def getTargetList(parsedCmd):
@@ -273,9 +304,11 @@ class TaskRunner:
 
         **Case 2**
 
-        If your task does not meet condition (1) then you must override both TaskRunner.getTargetList and
-        `TaskRunner.__call__`. You may do this however you see fit, so long as `TaskRunner.getTargetList`
-        returns a list, each of whose elements is sent to `TaskRunner.__call__`, which runs your task.
+        If your task does not meet condition (1) then you must override both
+        TaskRunner.getTargetList and `TaskRunner.__call__`. You may do this
+        however you see fit, so long as `TaskRunner.getTargetList`
+        returns a list, each of whose elements is sent to
+        `TaskRunner.__call__`, which runs your task.
         """
         return [(ref, kwargs) for ref in parsedCmd.id.refList]
 
@@ -285,24 +318,28 @@ class TaskRunner:
         Parameters
         ----------
         parsedCmd
-            Parsed command-line options (used for extra task args by some task runners).
+            Parsed command-line options (used for extra task args by some task
+            runners).
         args
-            Args tuple passed to `TaskRunner.__call__` (used for extra task arguments by some task runners).
+            Args tuple passed to `TaskRunner.__call__` (used for extra task
+            arguments by some task runners).
 
         Notes
         -----
-        ``makeTask`` can be called with either the ``parsedCmd`` argument or ``args`` argument set to None,
-        but it must construct identical Task instances in either case.
+        ``makeTask`` can be called with either the ``parsedCmd`` argument or
+        ``args`` argument set to None, but it must construct identical Task
+        instances in either case.
 
-        Subclasses may ignore this method entirely if they reimplement both `TaskRunner.precall` and
-        `TaskRunner.__call__`.
+        Subclasses may ignore this method entirely if they reimplement both
+        `TaskRunner.precall` and `TaskRunner.__call__`.
         """
         return self.TaskClass(config=self.config, log=self.log)
 
     def _precallImpl(self, task, parsedCmd):
         """The main work of `precall`.
 
-        We write package versions, schemas and configs, or compare these to existing files on disk if present.
+        We write package versions, schemas and configs, or compare these to
+        existing files on disk if present.
         """
         if not parsedCmd.noVersions:
             task.writePackageVersions(parsedCmd.butler, clobber=parsedCmd.clobberVersions)
@@ -314,15 +351,17 @@ class TaskRunner:
 
         Notes
         -----
-        Must return True if `TaskRunner.__call__` should subsequently be called.
+        Must return True if `TaskRunner.__call__` should subsequently be
+        called.
 
         .. warning::
 
-           Implementations must take care to ensure that no unpicklable attributes are added to the
-           TaskRunner itself, for compatibility with multiprocessing.
+           Implementations must take care to ensure that no unpicklable
+           attributes are added to the TaskRunner itself, for compatibility
+           with multiprocessing.
 
-        The default implementation writes package versions, schemas and configs, or compares them to existing
-        files on disk if present.
+        The default implementation writes package versions, schemas and
+        configs, or compares them to existing files on disk if present.
         """
         task = self.makeTask(parsedCmd=parsedCmd)
 
@@ -353,22 +392,26 @@ class TaskRunner:
 
             - ``dataRef``: the provided data reference.
             - ``metadata``: task metadata after execution of run.
-            - ``result``: result returned by task run, or `None` if the task fails.
-            - ``exitStatus``: 0 if the task completed successfully, 1 otherwise.
+            - ``result``: result returned by task run, or `None` if the task
+              fails.
+            - ``exitStatus``: 0 if the task completed successfully, 1
+              otherwise.
 
             If ``doReturnResults`` is `False` the struct contains:
 
-            - ``exitStatus``: 0 if the task completed successfully, 1 otherwise.
+            - ``exitStatus``: 0 if the task completed successfully, 1
+              otherwise.
 
         Notes
         -----
-        This default implementation assumes that the ``args`` is a tuple containing a data reference and a
-        dict of keyword arguments.
+        This default implementation assumes that the ``args`` is a tuple
+        containing a data reference and a dict of keyword arguments.
 
         .. warning::
 
-           If you override this method and wish to return something when ``doReturnResults`` is `False`,
-           then it must be picklable to support multiprocessing and it should be small enough that pickling
+           If you override this method and wish to return something when
+           ``doReturnResults`` is `False`, then it must be picklable to
+           support multiprocessing and it should be small enough that pickling
            and unpickling do not add excessive overhead.
         """
         dataRef, kwargs = args
@@ -391,7 +434,8 @@ class TaskRunner:
                 # non-zero, so the actual value used here is lost.
                 exitStatus = 1
 
-                # don't use a try block as we need to preserve the original exception
+                # don't use a try block as we need to preserve the original
+                # exception
                 eName = type(e).__name__
                 if hasattr(dataRef, "dataId"):
                     task.log.fatal("Failed on dataId=%s: %s: %s", dataRef.dataId, eName, e)
@@ -404,7 +448,8 @@ class TaskRunner:
                 if not isinstance(e, TaskError):
                     traceback.print_exc(file=sys.stderr)
 
-        # Ensure all errors have been logged and aren't hanging around in a buffer
+        # Ensure all errors have been logged and aren't hanging around in a
+        # buffer
         sys.stdout.flush()
         sys.stderr.flush()
 
@@ -435,44 +480,51 @@ class TaskRunner:
         dataRef
             Butler data reference that contains the data the task will process.
         kwargs
-            Any additional keyword arguments.  See `TaskRunner.getTargetList` above.
+            Any additional keyword arguments.  See `TaskRunner.getTargetList`
+            above.
 
         Notes
         -----
-        The default implementation of `TaskRunner.runTask` works for any command-line task which has a
-        runDataRef method that takes a data reference and an optional set of additional keyword arguments.
-        This method returns the results generated by the task's `runDataRef` method.
+        The default implementation of `TaskRunner.runTask` works for any
+        command-line task which has a ``runDataRef`` method that takes a data
+        reference and an optional set of additional keyword arguments.
+        This method returns the results generated by the task's `runDataRef`
+        method.
 
         """
         return task.runDataRef(dataRef, **kwargs)
 
 
 class LegacyTaskRunner(TaskRunner):
-    r"""A `TaskRunner` for `CmdLineTask`\ s which calls the `Task`\ 's `run` method on a `dataRef` rather
-    than the `runDataRef` method.
+    r"""A `TaskRunner` for `CmdLineTask`\ s which calls the `Task`\ 's `run`
+    method on a `dataRef` rather than the `runDataRef` method.
     """
 
     def runTask(self, task, dataRef, kwargs):
-        """Call `run` for this task instead of `runDataRef`.  See `TaskRunner.runTask` above for details.
+        """Call `run` for this task instead of `runDataRef`.  See
+        `TaskRunner.runTask` above for details.
         """
         return task.run(dataRef, **kwargs)
 
 
 class ButlerInitializedTaskRunner(TaskRunner):
-    r"""A `TaskRunner` for `CmdLineTask`\ s that require a ``butler`` keyword argument to be passed to
-    their constructor.
+    r"""A `TaskRunner` for `CmdLineTask`\ s that require a ``butler`` keyword
+    argument to be passed to their constructor.
     """
 
     def makeTask(self, parsedCmd=None, args=None):
-        """A variant of the base version that passes a butler argument to the task's constructor.
+        """A variant of the base version that passes a butler argument to the
+        task's constructor.
 
         Parameters
         ----------
         parsedCmd : `argparse.Namespace`
-            Parsed command-line options, as returned by the `~lsst.pipe.base.ArgumentParser`; if specified
-            then args is ignored.
+            Parsed command-line options, as returned by the
+            `~lsst.pipe.base.ArgumentParser`; if specified then args is
+            ignored.
         args
-            Other arguments; if ``parsedCmd`` is `None` then this must be specified.
+            Other arguments; if ``parsedCmd`` is `None` then this must be
+            specified.
 
         Raises
         ------
@@ -490,43 +542,52 @@ class ButlerInitializedTaskRunner(TaskRunner):
 
 
 class CmdLineTask(Task):
-    """Base class for command-line tasks: tasks that may be executed from the command-line.
+    """Base class for command-line tasks: tasks that may be executed from the
+    command-line.
 
     Notes
     -----
-    See :ref:`task-framework-overview` to learn what tasks are and :ref:`creating-a-command-line-task` for
-    more information about writing command-line tasks.
+    See :ref:`task-framework-overview` to learn what tasks are and
+    :ref:`creating-a-command-line-task` for more information about writing
+    command-line tasks.
 
     Subclasses must specify the following class variables:
 
-    - ``ConfigClass``: configuration class for your task (a subclass of `lsst.pex.config.Config`, or if your
-      task needs no configuration, then `lsst.pex.config.Config` itself).
-    - ``_DefaultName``: default name used for this task (a str).
+    - ``ConfigClass``: configuration class for your task (a subclass of
+      `lsst.pex.config.Config`, or if your task needs no configuration, then
+      `lsst.pex.config.Config` itself).
+    - ``_DefaultName``: default name used for this task (a `str`).
 
     Subclasses may also specify the following class variables:
 
-    - ``RunnerClass``: a task runner class. The default is ``TaskRunner``, which works for any task
-      with a runDataRef method that takes exactly one argument: a data reference. If your task does
-      not meet this requirement then you must supply a variant of ``TaskRunner``; see ``TaskRunner``
+    - ``RunnerClass``: a task runner class. The default is ``TaskRunner``,
+      which works for any task with a runDataRef method that takes exactly one
+      argument: a data reference. If your task does not meet this requirement
+      then you must supply a variant of ``TaskRunner``; see ``TaskRunner``
       for more information.
-    - ``canMultiprocess``: the default is `True`; set `False` if your task does not support multiprocessing.
+    - ``canMultiprocess``: the default is `True`; set `False` if your task
+      does not support multiprocessing.
 
     Subclasses must specify a method named ``runDataRef``:
 
-    - By default ``runDataRef`` accepts a single butler data reference, but you can specify an alternate
-      task runner (subclass of ``TaskRunner``) as the value of class variable ``RunnerClass`` if your run
-      method needs something else.
-    - ``runDataRef`` is expected to return its data in a `lsst.pipe.base.Struct`. This provides safety for
-      evolution of the task since new values may be added without harming existing code.
-    - The data returned by ``runDataRef`` must be picklable if your task is to support multiprocessing.
+    - By default ``runDataRef`` accepts a single butler data reference, but
+      you can specify an alternate task runner (subclass of ``TaskRunner``) as
+      the value of class variable ``RunnerClass`` if your run method needs
+      something else.
+    - ``runDataRef`` is expected to return its data in a
+      `lsst.pipe.base.Struct`. This provides safety for evolution of the task
+      since new values may be added without harming existing code.
+    - The data returned by ``runDataRef`` must be picklable if your task is to
+      support multiprocessing.
     """
     RunnerClass = TaskRunner
     canMultiprocess = True
 
     @classmethod
     def applyOverrides(cls, config):
-        """A hook to allow a task to change the values of its config *after* the camera-specific
-        overrides are loaded but before any command-line overrides are applied.
+        """A hook to allow a task to change the values of its config *after*
+        the camera-specific overrides are loaded but before any command-line
+        overrides are applied.
 
         Parameters
         ----------
@@ -535,13 +596,15 @@ class CmdLineTask(Task):
 
         Notes
         -----
-        This is necessary in some cases because the camera-specific overrides may retarget subtasks,
-        wiping out changes made in ConfigClass.setDefaults. See LSST Trac ticket #2282 for more discussion.
+        This is necessary in some cases because the camera-specific overrides
+        may retarget subtasks, wiping out changes made in
+        ConfigClass.setDefaults. See LSST Trac ticket #2282 for more
+        discussion.
 
         .. warning::
 
-           This is called by CmdLineTask.parseAndRun; other ways of constructing a config will not apply
-           these overrides.
+           This is called by CmdLineTask.parseAndRun; other ways of
+           constructing a config will not apply these overrides.
         """
         pass
 
@@ -558,10 +621,11 @@ class CmdLineTask(Task):
         log : `lsst.log.Log`-type, optional
             Log. If `None` use the default log.
         doReturnResults : `bool`, optional
-            If `True`, return the results of this task. Default is `False`. This is only intended for
-            unit tests and similar use. It can easily exhaust memory (if the task returns enough data and you
-            call it enough times) and it will fail when using multiprocessing if the returned data cannot be
-            pickled.
+            If `True`, return the results of this task. Default is `False`.
+            This is only intended for unit tests and similar use. It can
+            easily exhaust memory (if the task returns enough data and you
+            call it enough times) and it will fail when using multiprocessing
+            if the returned data cannot be pickled.
 
         Returns
         -------
@@ -575,7 +639,8 @@ class CmdLineTask(Task):
                 `~lsst.pipe.base.ArgumentParser.parse_args` method
                 (`argparse.Namespace`).
             ``taskRunner``
-                the task runner used to run the task (an instance of `Task.RunnerClass`).
+                the task runner used to run the task (an instance of
+                `Task.RunnerClass`).
             ``resultList``
                 results returned by the task runner's ``run`` method, one entry
                 per invocation (`list`). This will typically be a list of
@@ -585,13 +650,15 @@ class CmdLineTask(Task):
 
         Notes
         -----
-        Calling this method with no arguments specified is the standard way to run a command-line task
-        from the command-line. For an example see ``pipe_tasks`` ``bin/makeSkyMap.py`` or almost any other
-        file in that directory.
+        Calling this method with no arguments specified is the standard way to
+        run a command-line task from the command-line. For an example see
+        ``pipe_tasks`` ``bin/makeSkyMap.py`` or almost any other file in that
+        directory.
 
-        If one or more of the dataIds fails then this routine will exit (with a status giving the
-        number of failed dataIds) rather than returning this struct;  this behaviour can be
-        overridden by specifying the ``--noExit`` command-line option.
+        If one or more of the dataIds fails then this routine will exit (with
+        a status giving the number of failed dataIds) rather than returning
+        this struct;  this behaviour can be overridden by specifying the
+        ``--noExit`` command-line option.
         """
         if args is None:
             commandAsStr = " ".join(sys.argv)
@@ -603,7 +670,8 @@ class CmdLineTask(Task):
         if config is None:
             config = cls.ConfigClass()
         parsedCmd = argumentParser.parse_args(config=config, args=args, log=log, override=cls.applyOverrides)
-        # print this message after parsing the command so the log is fully configured
+        # print this message after parsing the command so the log is fully
+        # configured
         parsedCmd.log.info("Running: %s", commandAsStr)
 
         taskRunner = cls.RunnerClass(TaskClass=cls, parsedCmd=parsedCmd, doReturnResults=doReturnResults)
@@ -612,7 +680,8 @@ class CmdLineTask(Task):
         try:
             nFailed = sum(((res.exitStatus != 0) for res in resultList))
         except (TypeError, AttributeError) as e:
-            # NOTE: TypeError if resultList is None, AttributeError if it doesn't have exitStatus.
+            # NOTE: TypeError if resultList is None, AttributeError if it
+            # doesn't have exitStatus.
             parsedCmd.log.warn("Unable to retrieve exit status (%s); assuming success", e)
             nFailed = 0
 
@@ -640,13 +709,15 @@ class CmdLineTask(Task):
 
         Notes
         -----
-        By default this returns an `~lsst.pipe.base.ArgumentParser` with one ID argument named `--id` of
-        dataset type ``raw``.
+        By default this returns an `~lsst.pipe.base.ArgumentParser` with one
+        ID argument named `--id` of dataset type ``raw``.
 
-        Your task subclass may need to override this method to change the dataset type or data ref level,
-        or to add additional data ID arguments. If you add additional data ID arguments or your task's
-        runDataRef method takes more than a single data reference then you will also have to provide a
-        task-specific task runner (see TaskRunner for more information).
+        Your task subclass may need to override this method to change the
+        dataset type or data ref level, or to add additional data ID arguments.
+        If you add additional data ID arguments or your task's runDataRef
+        method takes more than a single data reference then you will also have
+        to provide a task-specific task runner (see TaskRunner for more
+        information).
         """
         parser = ArgumentParser(name=cls._DefaultName)
         parser.add_id_argument(name="--id", datasetType="raw",
@@ -654,18 +725,21 @@ class CmdLineTask(Task):
         return parser
 
     def writeConfig(self, butler, clobber=False, doBackup=True):
-        """Write the configuration used for processing the data, or check that an existing
-        one is equal to the new one if present.
+        """Write the configuration used for processing the data, or check that
+        an existing one is equal to the new one if present.
 
         Parameters
         ----------
         butler : `lsst.daf.persistence.Butler`
-            Data butler used to write the config. The config is written to dataset type
-            `CmdLineTask._getConfigName`.
+            Data butler used to write the config. The config is written to
+            dataset type `CmdLineTask._getConfigName`.
         clobber : `bool`, optional
-            A boolean flag that controls what happens if a config already has been saved:
-            - `True`: overwrite or rename the existing config, depending on ``doBackup``.
-            - `False`: raise `TaskError` if this config does not match the existing config.
+            A boolean flag that controls what happens if a config already has
+            been saved:
+            - `True`: overwrite or rename the existing config, depending on
+              ``doBackup``.
+            - `False`: raise `TaskError` if this config does not match the
+              existing config.
         doBackup : bool, optional
             Set to `True` to backup the config files if clobbering.
         """
@@ -694,25 +768,30 @@ class CmdLineTask(Task):
             butler.put(self.config, configName)
 
     def writeSchemas(self, butler, clobber=False, doBackup=True):
-        """Write the schemas returned by `lsst.pipe.base.Task.getAllSchemaCatalogs`.
+        """Write the schemas returned by
+        `lsst.pipe.base.Task.getAllSchemaCatalogs`.
 
         Parameters
         ----------
         butler : `lsst.daf.persistence.Butler`
-            Data butler used to write the schema. Each schema is written to the dataset type specified as the
-            key in the dict returned by `~lsst.pipe.base.Task.getAllSchemaCatalogs`.
+            Data butler used to write the schema. Each schema is written to the
+            dataset type specified as the key in the dict returned by
+            `~lsst.pipe.base.Task.getAllSchemaCatalogs`.
         clobber : `bool`, optional
-            A boolean flag that controls what happens if a schema already has been saved:
-            - `True`: overwrite or rename the existing schema, depending on ``doBackup``.
-            - `False`: raise `TaskError` if this schema does not match the existing schema.
+            A boolean flag that controls what happens if a schema already has
+            been saved:
+            - `True`: overwrite or rename the existing schema, depending on
+              ``doBackup``.
+            - `False`: raise `TaskError` if this schema does not match the
+              existing schema.
         doBackup : `bool`, optional
             Set to `True` to backup the schema files if clobbering.
 
         Notes
         -----
-        If ``clobber`` is `False` and an existing schema does not match a current schema,
-        then some schemas may have been saved successfully and others may not, and there is no easy way to
-        tell which is which.
+        If ``clobber`` is `False` and an existing schema does not match a
+        current schema, then some schemas may have been saved successfully
+        and others may not, and there is no easy way to tell which is which.
         """
         for dataset, catalog in self.getAllSchemaCatalogs().items():
             schemaDataset = dataset + "_schema"
@@ -735,7 +814,8 @@ class CmdLineTask(Task):
         ----------
         dataRef
             Butler data reference used to write the metadata.
-            The metadata is written to dataset type `CmdLineTask._getMetadataName`.
+            The metadata is written to dataset type
+            `CmdLineTask._getMetadataName`.
         """
         try:
             metadataName = self._getMetadataName()
@@ -752,9 +832,12 @@ class CmdLineTask(Task):
         butler : `lsst.daf.persistence.Butler`
             Data butler used to read/write the package versions.
         clobber : `bool`, optional
-            A boolean flag that controls what happens if versions already have been saved:
-            - `True`: overwrite or rename the existing version info, depending on ``doBackup``.
-            - `False`: raise `TaskError` if this version info does not match the existing.
+            A boolean flag that controls what happens if versions already have
+            been saved:
+            - `True`: overwrite or rename the existing version info, depending
+              on ``doBackup``.
+            - `False`: raise `TaskError` if this version info does not match
+              the existing.
         doBackup : `bool`, optional
             If `True` and clobbering, old package version files are backed up.
         dataset : `str`, optional
@@ -763,7 +846,8 @@ class CmdLineTask(Task):
         Raises
         ------
         TaskError
-            Raised if there is a version mismatch with current and persisted lists of package versions.
+            Raised if there is a version mismatch with current and persisted
+            lists of package versions.
 
         Notes
         -----
@@ -781,34 +865,40 @@ class CmdLineTask(Task):
         except Exception as exc:
             raise type(exc)(f"Unable to read stored version dataset {dataset} ({exc}); "
                             "consider using --clobber-versions or --no-versions")
-        # Note that because we can only detect python modules that have been imported, the stored
-        # list of products may be more or less complete than what we have now.  What's important is
-        # that the products that are in common have the same version.
+        # Note that because we can only detect python modules that have been
+        # imported, the stored list of products may be more or less complete
+        # than what we have now.  What's important is that the products that
+        # are in common have the same version.
         diff = packages.difference(old)
         if diff:
             versions_str = "; ".join(f"{pkg}: {diff[pkg][1]} vs {diff[pkg][0]}" for pkg in diff)
             raise TaskError(
                 f"Version mismatch ({versions_str}); consider using --clobber-versions or --no-versions")
-        # Update the old set of packages in case we have more packages that haven't been persisted.
+        # Update the old set of packages in case we have more packages that
+        # haven't been persisted.
         extra = packages.extra(old)
         if extra:
             old.update(packages)
             butler.put(old, dataset, doBackup=doBackup)
 
     def _getConfigName(self):
-        """Get the name of the config dataset type, or `None` if config is not to be persisted.
+        """Get the name of the config dataset type, or `None` if config is not
+        to be persisted.
 
         Notes
         -----
-        The name may depend on the config; that is why this is not a class method.
+        The name may depend on the config; that is why this is not a class
+        method.
         """
         return self._DefaultName + "_config"
 
     def _getMetadataName(self):
-        """Get the name of the metadata dataset type, or `None` if metadata is not to be persisted.
+        """Get the name of the metadata dataset type, or `None` if metadata is
+        not to be persisted.
 
         Notes
         -----
-        The name may depend on the config; that is why this is not a class method.
+        The name may depend on the config; that is why this is not a class
+        method.
         """
         return self._DefaultName + "_metadata"

--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -59,8 +59,8 @@ class PipelineTaskConfigMeta(pexConfig.ConfigMeta):
     """
     def __new__(cls, name, bases, dct, **kwargs):
         if name != "PipelineTaskConfig":
-            # Verify that a connection class was specified and the argument is an instance of
-            # PipelineTaskConfig
+            # Verify that a connection class was specified and the argument is
+            # an instance of PipelineTaskConfig
             if 'pipelineConnections' not in kwargs:
                 for base in bases:
                     if hasattr(base, "connections"):
@@ -72,22 +72,24 @@ class PipelineTaskConfigMeta(pexConfig.ConfigMeta):
             if not issubclass(connectionsClass, PipelineTaskConnections):
                 raise ValueError("Can only assign a PipelineTaskConnections Class to pipelineConnections")
 
-            # Create all the fields that will be used in the newly created sub config
-            # (under the attribute name "connections")
+            # Create all the fields that will be used in the newly created sub
+            # config (under the attribute name "connections")
             configConnectionsNamespace = {}
             for fieldName, obj in connectionsClass.allConnections.items():
                 configConnectionsNamespace[fieldName] = pexConfig.Field(dtype=str,
                                                                         doc=f"name for "
                                                                             f"connection {fieldName}",
                                                                         default=obj.name)
-            # If there are default templates also add them as fields to configure the template values
+            # If there are default templates also add them as fields to
+            # configure the template values
             if hasattr(connectionsClass, 'defaultTemplates'):
                 docString = "Template parameter used to format corresponding field template parameter"
                 for templateName, default in connectionsClass.defaultTemplates.items():
                     configConnectionsNamespace[templateName] = pexConfig.Field(dtype=str,
                                                                                doc=docString,
                                                                                default=default)
-            # add a reference to the connection class used to create this sub config
+            # add a reference to the connection class used to create this sub
+            # config
             configConnectionsNamespace['ConnectionsClass'] = connectionsClass
 
             # Create a new config class with the fields defined above

--- a/python/lsst/pipe/base/configOverrides.py
+++ b/python/lsst/pipe/base/configOverrides.py
@@ -94,8 +94,8 @@ class ConfigOverrides:
         Parameters
         ----------
         python_snippet: str
-            A string which is valid python code to be executed. This is done with
-            config as the only local accessible value.
+            A string which is valid python code to be executed. This is done
+            with config as the only local accessible value.
         """
         self._overrides.append((OverrideTypes.Python, python_snippet))
 
@@ -146,7 +146,8 @@ class ConfigOverrides:
                         # use safer ast.literal_eval, it only supports literals
                         value = ast.literal_eval(value)
                     except Exception:
-                        # eval failed, wrap exception with more user-friendly message
+                        # eval failed, wrap exception with more user-friendly
+                        # message
                         raise pexExceptions.RuntimeError(f"Unable to parse `{value}' into a Python object")
 
                 # this can throw in case of type mismatch

--- a/python/lsst/pipe/base/graph/_implDetails.py
+++ b/python/lsst/pipe/base/graph/_implDetails.py
@@ -82,13 +82,13 @@ class _DatasetTracker(Generic[_T, _U]):
     def _datasetDictToEdgeIterator(self) -> Generator[Tuple[Optional[_U], Optional[_U]], None, None]:
         """Helper function designed to be used in conjunction with
         `networkx.DiGraph.add_edges_from`. This takes a mapping of keys to
-        `_DatasetTrackers` and yields successive pairs of elements that are to be
-        considered connected by the graph.
+        `_DatasetTrackers` and yields successive pairs of elements that are to
+        be considered connected by the graph.
         """
         for entry in self._container.values():
             # If there is no inputs and only outputs (likely in test cases or
-            # building inits or something) use None as a Node, that will then be
-            # removed later
+            # building inits or something) use None as a Node, that will then
+            # be removed later
             inputs = entry.inputs or (None,)
             for inpt in inputs:
                 yield (entry.output, inpt)

--- a/python/lsst/pipe/base/graph/graph.py
+++ b/python/lsst/pipe/base/graph/graph.py
@@ -99,8 +99,9 @@ class QuantumGraph:
 
             # For each `Quantum` in the set of all `Quantum` for this task,
             # add a key to the `_DatasetTracker` that is a `DatasetRef` for one
-            # of the individual datasets inside the `Quantum`, with a value of a
-            # newly created QuantumNode to the appropriate input/output field.
+            # of the individual datasets inside the `Quantum`, with a value of
+            # a newly created QuantumNode to the appropriate input/output
+            # field.
             self._count += len(quantumSet)
             for quantum in quantumSet:
                 if _quantumToNodeId:
@@ -187,7 +188,8 @@ class QuantumGraph:
 
     @property
     def allDatasetTypes(self) -> Tuple[DatasetTypeName, ...]:
-        """Return all the `DatasetTypeNames` that are contained inside the graph.
+        """Return all the `DatasetTypeNames` that are contained inside the
+        graph.
 
         Returns
         -------
@@ -259,8 +261,9 @@ class QuantumGraph:
         Returns
         -------
         tasks : iterable of `TaskDef`
-            `TaskDef`s that have the specified `DatasetTypeName` as an input, list
-            will be empty if no tasks use specified `DatasetTypeName` as an input.
+            `TaskDef`s that have the specified `DatasetTypeName` as an input,
+            list will be empty if no tasks use specified `DatasetTypeName` as
+            an input.
 
         Raises
         ------
@@ -283,8 +286,8 @@ class QuantumGraph:
         Returns
         -------
         `TaskDef` or `None`
-            `TaskDef` that outputs `DatasetTypeName` as an output or None if none of
-            the tasks produce this `DatasetTypeName`.
+            `TaskDef` that outputs `DatasetTypeName` as an output or None if
+            none of the tasks produce this `DatasetTypeName`.
 
         Raises
         ------
@@ -336,9 +339,9 @@ class QuantumGraph:
         Returns
         -------
         result : list of `TaskDef`
-            List of the `TaskDef`s that have the name specified. Multiple values
-            are returned in the case that a task is used multiple times with
-            different labels.
+            List of the `TaskDef`s that have the name specified. Multiple
+            values are returned in the case that a task is used multiple times
+            with different labels.
         """
         results = []
         for task in self._quanta.keys():
@@ -497,7 +500,8 @@ class QuantumGraph:
         Parameters
         ----------
         node : `QuantumNode`
-            The node of the graph for which connected nodes are to be determined
+            The node of the graph for which connected nodes are to be
+            determined.
 
         Returns
         -------

--- a/python/lsst/pipe/base/graph/quantumNode.py
+++ b/python/lsst/pipe/base/graph/quantumNode.py
@@ -38,8 +38,9 @@ def _hashDsRef(ref: DatasetRef) -> int:
 @dataclass(frozen=True, eq=True)
 class NodeId:
     """This represents an unique identifier of a node within an individual
-    construction of a `QuantumGraph`. This identifier will stay constant through
-    a pickle, and any `QuantumGraph` methods that return a new `QuantumGraph`.
+    construction of a `QuantumGraph`. This identifier will stay constant
+    through a pickle, and any `QuantumGraph` methods that return a new
+    `QuantumGraph`.
 
     A `NodeId` will not be the same if a new graph is built containing the same
     information in a `QuantumNode`, or even built from exactly the same inputs.

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -250,8 +250,8 @@ class _QuantumScaffolding:
         allInputs.update(self.prerequisites.unpackMultiRefs())
         # Give the task's Connections class an opportunity to remove some
         # inputs, or complain if they are unacceptable.
-        # This will raise if one of the check conditions is not met, which is the intended
-        # behavior
+        # This will raise if one of the check conditions is not met, which is
+        # the intended behavior
         allInputs = self.task.taskDef.connections.adjustQuantum(allInputs)
         return Quantum(
             taskName=self.task.taskDef.taskName,
@@ -411,13 +411,15 @@ class _PipelineScaffolding:
             setattr(self, attr, _DatasetDict.fromDatasetTypes(getattr(datasetTypes, attr),
                                                               universe=registry.dimensions))
         # Aggregate all dimensions for all non-init, non-prerequisite
-        # DatasetTypes.  These are the ones we'll include in the big join query.
+        # DatasetTypes.  These are the ones we'll include in the big join
+        # query.
         self.dimensions = self.inputs.dimensions.union(self.intermediates.dimensions,
                                                        self.outputs.dimensions)
         # Construct scaffolding nodes for each Task, and add backreferences
         # to the Task from each DatasetScaffolding node.
-        # Note that there's only one scaffolding node for each DatasetType, shared by
-        # _PipelineScaffolding and all _TaskScaffoldings that reference it.
+        # Note that there's only one scaffolding node for each DatasetType,
+        # shared by _PipelineScaffolding and all _TaskScaffoldings that
+        # reference it.
         if isinstance(pipeline, Pipeline):
             pipeline = pipeline.toExpandedPipeline()
         self.tasks = [_TaskScaffolding(taskDef=taskDef, parent=self, datasetTypes=taskDatasetTypes)
@@ -539,22 +541,23 @@ class _PipelineScaffolding:
                         ref = DatasetRef(datasetType, datasetDataId)
                         refs[datasetDataId] = ref
                     refsForRow[datasetType.name] = ref
-                # Create _QuantumScaffolding objects for all tasks from this result
-                # row, noting that we might have created some already.
+                # Create _QuantumScaffolding objects for all tasks from this
+                # result row, noting that we might have created some already.
                 for task in self.tasks:
                     quantumDataId = commonDataId.subset(task.dimensions)
                     quantum = task.quanta.get(quantumDataId)
                     if quantum is None:
                         quantum = _QuantumScaffolding(task=task, dataId=quantumDataId)
                         task.quanta[quantumDataId] = quantum
-                    # Whether this is a new quantum or an existing one, we can now
-                    # associate the DatasetRefs for this row with it.  The fact
-                    # the fact that a Quantum data ID and a dataset data ID both
-                    # came from the same result row is what tells us they should
-                    # be associated.
-                    # Many of these associates will be duplicates (because another
-                    # query row that differed from this one only in irrelevant
-                    # dimensions already added them), and we use sets to skip.
+                    # Whether this is a new quantum or an existing one, we can
+                    # now associate the DatasetRefs for this row with it.  The
+                    # fact that a Quantum data ID and a dataset data ID both
+                    # came from the same result row is what tells us they
+                    # should be associated.
+                    # Many of these associates will be duplicates (because
+                    # another query row that differed from this one only in
+                    # irrelevant dimensions already added them), and we use
+                    # sets to skip.
                     for datasetType in task.inputs:
                         ref = refsForRow[datasetType.name]
                         quantum.inputs[datasetType.name][ref.dataId] = ref

--- a/python/lsst/pipe/base/pipeline.py
+++ b/python/lsst/pipe/base/pipeline.py
@@ -66,9 +66,9 @@ class LabelSpecifier:
     This structure may contain a set of labels to be used in subsetting a
     pipeline, or a beginning and end point. Beginning or end may be empty,
     in which case the range will be a half open interval. Unlike python
-    iteration bounds, end bounds are *INCLUDED*. Note that range based selection
-    is not well defined for pipelines that are not linear in nature, and
-    correct behavior is not guaranteed, or may vary from run to run.
+    iteration bounds, end bounds are *INCLUDED*. Note that range based
+    selection is not well defined for pipelines that are not linear in nature,
+    and correct behavior is not guaranteed, or may vary from run to run.
     """
     labels: Optional[Set[str]] = None
     begin: Optional[str] = None
@@ -399,14 +399,15 @@ class Pipeline:
         Parameters
         ----------
         instrument : `~lsst.daf.butler.instrument.Instrument` or `str`
-            Either a derived class object of a `lsst.daf.butler.instrument` or a
-            string corresponding to a fully qualified
+            Either a derived class object of a `lsst.daf.butler.instrument` or
+            a string corresponding to a fully qualified
             `lsst.daf.butler.instrument` name.
         """
         if isinstance(instrument, str):
             pass
         else:
-            # TODO: assume that this is a subclass of Instrument, no type checking
+            # TODO: assume that this is a subclass of Instrument, no type
+            # checking
             instrument = f"{instrument.__module__}.{instrument.__qualname__}"
         self._pipelineIR.instrument = instrument
 
@@ -562,8 +563,8 @@ class Pipeline:
         if self._pipelineIR.contracts is not None:
             label_to_config = {x.label: x.config for x in taskDefs}
             for contract in self._pipelineIR.contracts:
-                # execute this in its own line so it can raise a good error message if there was problems
-                # with the eval
+                # execute this in its own line so it can raise a good error
+                # message if there was problems with the eval
                 success = eval(contract.contract, None, label_to_config)
                 if not success:
                     extra_info = f": {contract.msg}" if contract.msg is not None else ""
@@ -730,8 +731,8 @@ class TaskDatasetTypes:
         # optionally add output dataset for metadata
         outputs = makeDatasetTypesSet("outputs", freeze=False)
         if taskDef.metadataDatasetName is not None:
-            # Metadata is supposed to be of the PropertySet type, its dimensions
-            # correspond to a task quantum
+            # Metadata is supposed to be of the PropertySet type, its
+            # dimensions correspond to a task quantum
             dimensions = registry.dimensions.extract(taskDef.connections.dimensions)
             outputs |= {DatasetType(taskDef.metadataDatasetName, dimensions, "PropertySet")}
         outputs.freeze()

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -104,7 +104,8 @@ class ConfigIR:
     """
     file: List[str] = field(default_factory=list)
     """A list of paths which points to a file containing config overrides to be
-    applied. This value may be an empty list if there are no overrides to apply.
+    applied. This value may be an empty list if there are no overrides to
+    apply.
     """
     rest: dict = field(default_factory=dict)
     """This is a dictionary of key value pairs, where the keys are strings
@@ -117,7 +118,8 @@ class ConfigIR:
         """
         accumulate = {}
         for name in ("python", "dataId", "file"):
-            # if this attribute is thruthy add it to the accumulation dictionary
+            # if this attribute is thruthy add it to the accumulation
+            # dictionary
             if getattr(self, name):
                 accumulate[name] = getattr(self, name)
         # Add the dictionary containing the rest of the config keys to the
@@ -202,9 +204,9 @@ class TaskIR:
         """Adds a `ConfigIR` to this task if one is not present. Merges configs
         if there is a `ConfigIR` present and the dataId keys of both configs
         match, otherwise adds a new entry to the config list. The exception to
-        the above is that if either the last config or other_config has a python
-        block, then other_config is always added, as python blocks can modify
-        configs in ways that cannot be predicted.
+        the above is that if either the last config or other_config has a
+        python block, then other_config is always added, as python blocks can
+        modify configs in ways that cannot be predicted.
 
         Parameters
         ----------
@@ -233,9 +235,9 @@ class InheritIR:
     """
     location: str
     """This is the location of the pipeline to inherit. The path should be
-    specified as an absolute path. Environment variables may be used in the path
-    and should be specified as a python string template, with the name of the
-    environment variable inside braces.
+    specified as an absolute path. Environment variables may be used in the
+    path and should be specified as a python string template, with the name of
+    the environment variable inside braces.
     """
     include: Union[List[str], None] = None
     """List of tasks that should be included when inheriting this pipeline.
@@ -332,8 +334,8 @@ class PipelineIR:
         Parameters
         ---------
         loaded_yaml : `dict`
-            A dictionary which matches the structure that would be produced by a
-            yaml reader which parses a pipeline definition document
+            A dictionary which matches the structure that would be produced by
+            a yaml reader which parses a pipeline definition document
         """
         loaded_contracts = loaded_yaml.pop("contracts", [])
         if isinstance(loaded_contracts, str):
@@ -351,8 +353,8 @@ class PipelineIR:
         Parameters
         ---------
         loaded_yaml : `dict`
-            A dictionary which matches the structure that would be produced by a
-            yaml reader which parses a pipeline definition document
+            A dictionary which matches the structure that would be produced by
+            a yaml reader which parses a pipeline definition document
         """
         def process_args(argument: Union[str, dict]) -> dict:
             if isinstance(argument, str):
@@ -400,8 +402,8 @@ class PipelineIR:
         Parameters
         ---------
         loaded_yaml : `dict`
-            A dictionary which matches the structure that would be produced by a
-            yaml reader which parses a pipeline definition document
+            A dictionary which matches the structure that would be produced by
+            a yaml reader which parses a pipeline definition document
         """
         self.tasks = {}
         tmp_tasks = loaded_yaml.pop("tasks", None)

--- a/python/lsst/pipe/base/pipelineTask.py
+++ b/python/lsst/pipe/base/pipelineTask.py
@@ -109,13 +109,17 @@ class PipelineTask(Task):
 
         Examples
         --------
-        Typical implementation of this method may look like::
+        Typical implementation of this method may look like:
+
+        .. code-block:: python
 
             def run(self, input, calib):
-                # "input", "calib", and "output" are the names of the config fields
+                # "input", "calib", and "output" are the names of the config
+                # fields
 
-                # Assuming that input/calib datasets are `scalar` they are simple objects,
-                # do something with inputs and calibs, produce output image.
+                # Assuming that input/calib datasets are `scalar` they are
+                # simple objects, do something with inputs and calibs, produce
+                # output image.
                 image = self.makeImage(input, calib)
 
                 # If output dataset is `scalar` then return object, not list
@@ -126,20 +130,26 @@ class PipelineTask(Task):
 
     def runQuantum(self, butlerQC: ButlerQuantumContext, inputRefs: InputQuantizedConnection,
                    outputRefs: OutputQuantizedConnection):
-        """Method to do butler IO and or transforms to provide in memory objects for tasks run method
+        """Method to do butler IO and or transforms to provide in memory
+        objects for tasks run method
 
         Parameters
         ----------
         butlerQC : `ButlerQuantumContext`
-            A butler which is specialized to operate in the context of a `lsst.daf.butler.Quantum`.
+            A butler which is specialized to operate in the context of a
+            `lsst.daf.butler.Quantum`.
         inputRefs : `InputQuantizedConnection`
-            Datastructure whose attribute names are the names that identify connections defined in
-            corresponding `PipelineTaskConnections` class. The values of these attributes are the
-            `lsst.daf.butler.DatasetRef` objects associated with the defined input/prerequisite connections.
+            Datastructure whose attribute names are the names that identify
+            connections defined in corresponding `PipelineTaskConnections`
+            class. The values of these attributes are the
+            `lsst.daf.butler.DatasetRef` objects associated with the defined
+            input/prerequisite connections.
         outputRefs : `OutputQuantizedConnection`
-            Datastructure whose attribute names are the names that identify connections defined in
-            corresponding `PipelineTaskConnections` class. The values of these attributes are the
-            `lsst.daf.butler.DatasetRef` objects associated with the defined output connections.
+            Datastructure whose attribute names are the names that identify
+            connections defined in corresponding `PipelineTaskConnections`
+            class. The values of these attributes are the
+            `lsst.daf.butler.DatasetRef` objects associated with the defined
+            output connections.
         """
         inputs = butlerQC.get(inputRefs)
         outputs = self.run(**inputs)

--- a/python/lsst/pipe/base/struct.py
+++ b/python/lsst/pipe/base/struct.py
@@ -33,21 +33,26 @@ class Struct:
 
     Notes
     -----
-    Intended to be used for the return value from `~lsst.pipe.base.Task.run` and other `~lsst.pipe.base.Task`
-    methods, and useful for any method that returns multiple values.
+    Intended to be used for the return value from `~lsst.pipe.base.Task.run`
+    and other `~lsst.pipe.base.Task` methods, and useful for any method that
+    returns multiple values.
 
-    The intent is to allow accessing returned items by name, instead of unpacking a tuple.
-    This makes the code much more robust and easier to read. It allows one to change what values are returned
-    without inducing mysterious failures: adding items is completely safe, and removing or renaming items
-    causes errors that are caught quickly and reported in a way that is easy to understand.
+    The intent is to allow accessing returned items by name, instead of
+    unpacking a tuple.  This makes the code much more robust and easier to
+    read. It allows one to change what values are returned without inducing
+    mysterious failures: adding items is completely safe, and removing or
+    renaming items causes errors that are caught quickly and reported in a way
+    that is easy to understand.
 
-    The primary reason for using Struct instead of dict is that the fields may be accessed as attributes,
-    e.g. ``aStruct.foo`` instead of ``aDict["foo"]``. Admittedly this only saves a few characters, but it
+    The primary reason for using Struct instead of dict is that the fields may
+    be accessed as attributes, e.g. ``aStruct.foo`` instead of
+    ``aDict["foo"]``. Admittedly this only saves a few characters, but it
     makes the code significantly more readable.
 
-    Struct is preferred over named tuples, because named tuples can be used as ordinary tuples, thus losing
-    all the safety advantages of Struct. In addition, named tuples are clumsy to define and Structs
-    are much more mutable (e.g. one can trivially combine Structs and add additional fields).
+    Struct is preferred over named tuples, because named tuples can be used as
+    ordinary tuples, thus losing all the safety advantages of Struct. In
+    addition, named tuples are clumsy to define and Structs are much more
+    mutable (e.g. one can trivially combine Structs and add additional fields).
 
     Examples
     --------
@@ -63,7 +68,8 @@ class Struct:
             self.__safeAdd(name, val)
 
     def __safeAdd(self, name, val):
-        """Add a field if it does not already exist and name does not start with ``__`` (two underscores).
+        """Add a field if it does not already exist and name does not start
+        with ``__`` (two underscores).
 
         Parameters
         ----------
@@ -75,7 +81,8 @@ class Struct:
         Raises
         ------
         RuntimeError
-            Raised if name already exists or starts with ``__`` (two underscores).
+            Raised if name already exists or starts with ``__`` (two
+            underscores).
         """
         if hasattr(self, name):
             raise RuntimeError(f"Item {name!r} already exists")
@@ -89,12 +96,14 @@ class Struct:
         Returns
         -------
         structDict : `dict`
-            Dictionary with field names as keys and field values as values. The values are shallow copies.
+            Dictionary with field names as keys and field values as values.
+            The values are shallow copies.
         """
         return self.__dict__.copy()
 
     def mergeItems(self, struct, *nameList):
-        """Copy specified fields from another struct, provided they don't already exist.
+        """Copy specified fields from another struct, provided they don't
+        already exist.
 
         Parameters
         ----------
@@ -106,8 +115,9 @@ class Struct:
         Raises
         ------
         RuntimeError
-            Raised if any item in nameList already exists in self (but any items before the conflicting item
-            in nameList will have been copied).
+            Raised if any item in nameList already exists in self (but any
+            items before the conflicting item in nameList will have been
+            copied).
 
         Examples
         --------

--- a/python/lsst/pipe/base/task.py
+++ b/python/lsst/pipe/base/task.py
@@ -370,7 +370,30 @@ class Task:
         """
         return f"{self._fullName}.{name}"
 
+    @staticmethod
+    def _unpickle_via_factory(factory, args, kwargs):
+        """Unpickle something by calling a factory
+
+        Allows subclasses to unpickle using `__reduce__` with keyword
+        arguments as well as positional arguments.
+        """
+        return factory(*args, **kwargs)
+
+    def _reduce_kwargs(self):
+        """Returns a dict of the keyword arguments that should be used
+        by `__reduce__`.
+
+        Subclasses with additional arguments should always call the parent
+        class method to ensure that the standard parameters are included.
+
+        Returns
+        -------
+        kwargs : `dict`
+            Keyword arguments to be used when pickling.
+        """
+        return dict(config=self.config, name=self._name, parentTask=self._parentTask,)
+
     def __reduce__(self):
         """Pickler.
         """
-        return self.__class__, (self.config, self._name, self._parentTask, None)
+        return self._unpickle_via_factory, (self.__class__, [], self._reduce_kwargs())

--- a/python/lsst/pipe/base/task.py
+++ b/python/lsst/pipe/base/task.py
@@ -37,7 +37,8 @@ class TaskError(Exception):
     -----
     Examples of such errors:
 
-    - processCcd is asked to run detection, but not calibration, and no calexp is found.
+    - processCcd is asked to run detection, but not calibration, and no calexp
+      is found.
     - coadd finds no valid images in the specified patch.
     """
     pass
@@ -46,30 +47,35 @@ class TaskError(Exception):
 class Task:
     r"""Base class for data processing tasks.
 
-    See :ref:`task-framework-overview` to learn what tasks are, and :ref:`creating-a-task` for more
-    information about writing tasks.
+    See :ref:`task-framework-overview` to learn what tasks are, and
+    :ref:`creating-a-task` for more information about writing tasks.
 
     Parameters
     ----------
     config : `Task.ConfigClass` instance, optional
-        Configuration for this task (an instance of Task.ConfigClass, which is a task-specific subclass of
-        `lsst.pex.config.Config`, or `None`. If `None`:
+        Configuration for this task (an instance of Task.ConfigClass, which
+        is a task-specific subclass of `lsst.pex.config.Config`, or `None`.
+        If `None`:
 
         - If parentTask specified then defaults to parentTask.config.\<name>
         - If parentTask is None then defaults to self.ConfigClass()
 
     name : `str`, optional
-        Brief name of task, or `None`; if `None` then defaults to `Task._DefaultName`
+        Brief name of task, or `None`; if `None` then defaults to
+        `Task._DefaultName`
     parentTask : `Task`-type, optional
         The parent task of this subtask, if any.
 
-        - If `None` (a top-level task) then you must specify config and name is ignored.
+        - If `None` (a top-level task) then you must specify config and name
+          is ignored.
         - If not `None` (a subtask) then you must specify name.
     log : `lsst.log.Log`, optional
-        Log whose name is used as a log name prefix, or `None` for no prefix. Ignored if is parentTask
-        specified, in which case ``parentTask.log``\ 's name is used as a prefix. The task's log name is
-        ``prefix + "." + name`` if a prefix exists, else ``name``. The task's log is then a child logger of
-        ``parentTask.log`` (if ``parentTask`` specified), or a child logger of the log from the argument
+        Log whose name is used as a log name prefix, or `None` for no prefix.
+        Ignored if is parentTask specified, in which case
+        ``parentTask.log``\ 's name is used as a prefix. The task's log name is
+        ``prefix + "." + name`` if a prefix exists, else ``name``. The task's
+        log is then a child logger of ``parentTask.log`` (if ``parentTask``
+        specified), or a child logger of the log from the argument
         (if ``log`` is not `None`).
 
     Raises
@@ -86,35 +92,42 @@ class Task:
     Useful attributes include:
 
     - ``log``: an lsst.log.Log
-    - ``config``: task-specific configuration; an instance of ``ConfigClass`` (see below).
-    - ``metadata``: an `lsst.daf.base.PropertyList` for collecting task-specific metadata,
-        e.g. data quality and performance metrics. This is data that is only meant to be
-        persisted, never to be used by the task.
+    - ``config``: task-specific configuration; an instance of ``ConfigClass``
+      (see below).
+    - ``metadata``: an `lsst.daf.base.PropertyList` for collecting
+      task-specific metadata, e.g. data quality and performance metrics.
+      This is data that is only meant to be persisted, never to be used by
+      the task.
 
-    Subclasses typically have a method named ``runDataRef`` to perform the main data processing. Details:
+    Subclasses typically have a method named ``runDataRef`` to perform the
+    main data processing. Details:
 
-    - ``runDataRef`` should process the minimum reasonable amount of data, typically a single CCD.
-      Iteration, if desired, is performed by a caller of the method. This is good design and allows
-      multiprocessing without the run method having to support it directly.
+    - ``runDataRef`` should process the minimum reasonable amount of data,
+      typically a single CCD.  Iteration, if desired, is performed by a caller
+      of the method. This is good design and allows multiprocessing without
+      the run method having to support it directly.
     - If ``runDataRef`` can persist or unpersist data:
 
-      - ``runDataRef`` should accept a butler data reference (or a collection of data references,
-        if appropriate, e.g. coaddition).
-      - There should be a way to run the task without persisting data. Typically the run method returns all
-        data, even if it is persisted, and the task's config method offers a flag to disable persistence.
+      - ``runDataRef`` should accept a butler data reference (or a collection
+        of data references, if appropriate, e.g. coaddition).
+      - There should be a way to run the task without persisting data.
+        Typically the run method returns all data, even if it is persisted, and
+        the task's config method offers a flag to disable persistence.
 
-    **Deprecated:** Tasks other than cmdLineTask.CmdLineTask%s should *not* accept a blob such as a butler
-    data reference.  How we will handle data references is still TBD, so don't make changes yet!
+    **Deprecated:** Tasks other than cmdLineTask.CmdLineTask%s should *not*
+    accept a blob such as a butler data reference.  How we will handle data
+    references is still TBD, so don't make changes yet!
     RHL 2014-06-27
 
-    Subclasses must also have an attribute ``ConfigClass`` that is a subclass of `lsst.pex.config.Config`
-    which configures the task. Subclasses should also have an attribute ``_DefaultName``:
-    the default name if there is no parent task. ``_DefaultName`` is required for subclasses of
-    `~lsst.pipe.base.CmdLineTask` and recommended for subclasses of Task because it simplifies construction
-    (e.g. for unit tests).
+    Subclasses must also have an attribute ``ConfigClass`` that is a subclass
+    of `lsst.pex.config.Config` which configures the task. Subclasses should
+    also have an attribute ``_DefaultName``: the default name if there is no
+    parent task. ``_DefaultName`` is required for subclasses of
+    `~lsst.pipe.base.CmdLineTask` and recommended for subclasses of Task
+    because it simplifies construction (e.g. for unit tests).
 
-    Tasks intended to be run from the command line should be subclasses of `~lsst.pipe.base.CmdLineTask`
-    not Task.
+    Tasks intended to be run from the command line should be subclasses of
+    `~lsst.pipe.base.CmdLineTask` not Task.
     """
 
     def __init__(self, config=None, name=None, parentTask=None, log=None):
@@ -162,22 +175,25 @@ class Task:
         Returns
         -------
         schemaCatalogs : `dict`
-            Keys are butler dataset type, values are an empty catalog (an instance of the appropriate
-            `lsst.afw.table` Catalog type) for this task.
+            Keys are butler dataset type, values are an empty catalog (an
+            instance of the appropriate `lsst.afw.table` Catalog type) for
+            this task.
 
         Notes
         -----
 
         .. warning::
 
-           Subclasses that use schemas must override this method. The default implemenation returns
-           an empty dict.
+           Subclasses that use schemas must override this method. The default
+           implementation returns an empty dict.
 
-        This method may be called at any time after the Task is constructed, which means that all task
-        schemas should be computed at construction time, *not* when data is actually processed. This
-        reflects the philosophy that the schema should not depend on the data.
+        This method may be called at any time after the Task is constructed,
+        which means that all task schemas should be computed at construction
+        time, *not* when data is actually processed. This reflects the
+        philosophy that the schema should not depend on the data.
 
-        Returning catalogs rather than just schemas allows us to save e.g. slots for SourceCatalog as well.
+        Returning catalogs rather than just schemas allows us to save e.g.
+        slots for SourceCatalog as well.
 
         See also
         --------
@@ -186,21 +202,24 @@ class Task:
         return {}
 
     def getAllSchemaCatalogs(self):
-        """Get schema catalogs for all tasks in the hierarchy, combining the results into a single dict.
+        """Get schema catalogs for all tasks in the hierarchy, combining the
+        results into a single dict.
 
         Returns
         -------
         schemacatalogs : `dict`
-            Keys are butler dataset type, values are a empty catalog (an instance of the appropriate
-            lsst.afw.table Catalog type) for all tasks in the hierarchy, from the top-level task down
+            Keys are butler dataset type, values are a empty catalog (an
+            instance of the appropriate `lsst.afw.table` Catalog type) for all
+            tasks in the hierarchy, from the top-level task down
             through all subtasks.
 
         Notes
         -----
-        This method may be called on any task in the hierarchy; it will return the same answer, regardless.
+        This method may be called on any task in the hierarchy; it will return
+        the same answer, regardless.
 
-        The default implementation should always suffice. If your subtask uses schemas the override
-        `Task.getSchemaCatalogs`, not this method.
+        The default implementation should always suffice. If your subtask uses
+        schemas the override `Task.getSchemaCatalogs`, not this method.
         """
         schemaDict = self.getSchemaCatalogs()
         for subtask in self._taskDict.values():
@@ -213,19 +232,21 @@ class Task:
         Returns
         -------
         metadata : `lsst.daf.base.PropertySet`
-            The `~lsst.daf.base.PropertySet` keys are the full task name. Values are metadata
-            for the top-level task and all subtasks, sub-subtasks, etc..
+            The `~lsst.daf.base.PropertySet` keys are the full task name.
+            Values are metadata for the top-level task and all subtasks,
+            sub-subtasks, etc.
 
         Notes
         -----
-        The returned metadata includes timing information (if ``@timer.timeMethod`` is used)
-        and any metadata set by the task. The name of each item consists of the full task name
-        with ``.`` replaced by ``:``, followed by ``.`` and the name of the item, e.g.::
+        The returned metadata includes timing information (if
+        ``@timer.timeMethod`` is used) and any metadata set by the task. The
+        name of each item consists of the full task name with ``.`` replaced
+        by ``:``, followed by ``.`` and the name of the item, e.g.::
 
             topLevelTaskName:subtaskName:subsubtaskName.itemName
 
-        using ``:`` in the full task name disambiguates the rare situation that a task has a subtask
-        and a metadata item with the same name.
+        using ``:`` in the full task name disambiguates the rare situation
+        that a task has a subtask and a metadata item with the same name.
         """
         fullMetadata = dafBase.PropertySet()
         for fullName, task in self.getTaskDict().items():
@@ -233,17 +254,20 @@ class Task:
         return fullMetadata
 
     def getFullName(self):
-        """Get the task name as a hierarchical name including parent task names.
+        """Get the task name as a hierarchical name including parent task
+        names.
 
         Returns
         -------
         fullName : `str`
-            The full name consists of the name of the parent task and each subtask separated by periods.
-            For example:
+            The full name consists of the name of the parent task and each
+            subtask separated by periods. For example:
 
             - The full name of top-level task "top" is simply "top".
-            - The full name of subtask "sub" of top-level task "top" is "top.sub".
-            - The full name of subtask "sub2" of subtask "sub" of top-level task "top" is "top.sub.sub2".
+            - The full name of subtask "sub" of top-level task "top" is
+              "top.sub".
+            - The full name of subtask "sub2" of subtask "sub" of top-level
+              task "top" is "top.sub.sub2".
         """
         return self._fullName
 
@@ -267,29 +291,31 @@ class Task:
         Returns
         -------
         taskDict : `dict`
-            Dictionary containing full task name: task object for the top-level task and all subtasks,
-            sub-subtasks, etc..
+            Dictionary containing full task name: task object for the top-level
+            task and all subtasks, sub-subtasks, etc.
         """
         return self._taskDict.copy()
 
     def makeSubtask(self, name, **keyArgs):
-        """Create a subtask as a new instance as the ``name`` attribute of this task.
+        """Create a subtask as a new instance as the ``name`` attribute of this
+        task.
 
         Parameters
         ----------
         name : `str`
             Brief name of the subtask.
         keyArgs
-            Extra keyword arguments used to construct the task. The following arguments are automatically
-            provided and cannot be overridden:
+            Extra keyword arguments used to construct the task. The following
+            arguments are automatically provided and cannot be overridden:
 
             - "config".
             - "parentTask".
 
         Notes
         -----
-        The subtask must be defined by ``Task.config.name``, an instance of pex_config ConfigurableField
-        or RegistryField.
+        The subtask must be defined by ``Task.config.name``, an instance of
+        `~lsst.pex.config.ConfigurableField` or
+        `~lsst.pex.config.RegistryField`.
         """
         taskField = getattr(self.config, name, None)
         if taskField is None:
@@ -299,18 +325,22 @@ class Task:
 
     @contextlib.contextmanager
     def timer(self, name, logLevel=Log.DEBUG):
-        """Context manager to log performance data for an arbitrary block of code.
+        """Context manager to log performance data for an arbitrary block of
+        code.
 
         Parameters
         ----------
         name : `str`
-            Name of code being timed; data will be logged using item name: ``Start`` and ``End``.
+            Name of code being timed; data will be logged using item name:
+            ``Start`` and ``End``.
         logLevel
             A `lsst.log` level constant.
 
         Examples
         --------
-        Creating a timer context::
+        Creating a timer context:
+
+        .. code-block:: python
 
             with self.timer("someCodeToTime"):
                 pass  # code to time
@@ -341,17 +371,21 @@ class Task:
 
         Examples
         --------
-        Provides a convenient way to specify this task is a subtask of another task.
+        Provides a convenient way to specify this task is a subtask of another
+        task.
 
-        Here is an example of use::
+        Here is an example of use:
 
-            class OtherTaskConfig(lsst.pex.config.Config)
-                aSubtask = ATaskClass.makeField("a brief description of what this task does")
+        .. code-block:: python
+
+            class OtherTaskConfig(lsst.pex.config.Config):
+                aSubtask = ATaskClass.makeField("brief description of task")
         """
         return ConfigurableField(doc=doc, target=cls)
 
     def _computeFullName(self, name):
-        """Compute the full name of a subtask or metadata item, given its brief name.
+        """Compute the full name of a subtask or metadata item, given its brief
+        name.
 
         Parameters
         ----------
@@ -361,12 +395,14 @@ class Task:
         Returns
         -------
         fullName : `str`
-            The full name: the ``name`` argument prefixed by the full task name and a period.
+            The full name: the ``name`` argument prefixed by the full task name
+            and a period.
 
         Notes
         -----
         For example: if the full name of this task is "top.sub.sub2"
-        then ``_computeFullName("subname")`` returns ``"top.sub.sub2.subname"``.
+        then ``_computeFullName("subname")`` returns
+        ``"top.sub.sub2.subname"``.
         """
         return f"{self._fullName}.{name}"
 

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -243,7 +243,8 @@ def runTestQuantum(task, butler, quantum, mockRun=True):
 
 
 def assertValidOutput(task, result):
-    """Test that the output of a call to ``run`` conforms to its own connections.
+    """Test that the output of a call to ``run`` conforms to its own
+    connections.
 
     Parameters
     ----------
@@ -274,10 +275,12 @@ def assertValidOutput(task, result):
             if not isinstance(output, collections.abc.Sequence):
                 raise AssertionError(f"Expected {name} to be a sequence, got {output} instead.")
         else:
-            # use lazy evaluation to not use StorageClassFactory unless necessary
+            # use lazy evaluation to not use StorageClassFactory unless
+            # necessary
             if isinstance(output, collections.abc.Sequence) \
                     and not issubclass(
                         StorageClassFactory().getStorageClass(connection.storageClass).pytype,
                         collections.abc.Sequence):
                 raise AssertionError(f"Expected {name} to be a single value, got {output} instead.")
-        # no test for storageClass, as I'm not sure how much persistence depends on duck-typing
+        # no test for storageClass, as I'm not sure how much persistence
+        # depends on duck-typing

--- a/python/lsst/pipe/base/timer.py
+++ b/python/lsst/pipe/base/timer.py
@@ -39,8 +39,8 @@ def logPairs(obj, pairs, logLevel=Log.DEBUG):
     obj : `lsst.pipe.base.Task`-type
         A `~lsst.pipe.base.Task` or any other object with these two attributes:
 
-        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other object with
-          ``add(name, value)`` method).
+        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other
+          object with ``add(name, value)`` method).
         - ``log`` an instance of `lsst.log.Log`.
 
     pairs : sequence
@@ -51,7 +51,8 @@ def logPairs(obj, pairs, logLevel=Log.DEBUG):
     strList = []
     for name, value in pairs:
         try:
-            # Use LongLong explicitly here in case an early value in the sequence is int-sized
+            # Use LongLong explicitly here in case an early value in the
+            # sequence is int-sized
             obj.metadata.addLongLong(name, value)
         except TypeError:
             obj.metadata.add(name, value)
@@ -67,13 +68,14 @@ def logInfo(obj, prefix, logLevel=Log.DEBUG):
     obj : `lsst.pipe.base.Task`-type
         A `~lsst.pipe.base.Task` or any other object with these two attributes:
 
-        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other object with
-          ``add(name, value)`` method).
+        - ``metadata`` an instance of `lsst.daf.base.PropertyList`` (or other
+          object with ``add(name, value)`` method).
         - ``log`` an instance of `lsst.log.Log`.
 
     prefix
-        Name prefix, the resulting entries are ``CpuTime``, etc.. For example timeMethod uses
-        ``prefix = Start`` when the method begins and ``prefix = End`` when the method ends.
+        Name prefix, the resulting entries are ``CpuTime``, etc.. For example
+        timeMethod uses ``prefix = Start`` when the method begins and
+        ``prefix = End`` when the method ends.
     logLevel : optional
         Log level (an `lsst.log` level constant, such as `lsst.log.Log.DEBUG`).
 
@@ -81,12 +83,14 @@ def logInfo(obj, prefix, logLevel=Log.DEBUG):
     -----
     Logged items include:
 
-    - ``Utc``: UTC date in ISO format (only in metadata since log entries have timestamps).
+    - ``Utc``: UTC date in ISO format (only in metadata since log entries have
+      timestamps).
     - ``CpuTime``: System + User CPU time (seconds). This should only be used
         in differential measurements; the time reference point is undefined.
     - ``MaxRss``: maximum resident set size.
 
-    All logged resource information is only for the current process; child processes are excluded.
+    All logged resource information is only for the current process; child
+    processes are excluded.
     """
     cpuTime = time.process_time()
     utcStr = datetime.datetime.utcnow().isoformat()
@@ -119,20 +123,23 @@ def timeMethod(func):
 
     Notes
     -----
-    Writes various measures of time and possibly memory usage to the task's metadata; all items are prefixed
-    with the function name.
+    Writes various measures of time and possibly memory usage to the task's
+    metadata; all items are prefixed with the function name.
 
     .. warning::
 
-       This decorator only works with instance methods of Task, or any class with these attributes:
+       This decorator only works with instance methods of Task, or any class
+       with these attributes:
 
-       - ``metadata``: an instance of `lsst.daf.base.PropertyList` (or other object with
-         ``add(name, value)`` method).
+       - ``metadata``: an instance of `lsst.daf.base.PropertyList` (or other
+         object with ``add(name, value)`` method).
        - ``log``: an instance of `lsst.log.Log`.
 
     Examples
     --------
-    To use::
+    To use:
+
+    .. code-block:: python
 
         import lsst.pipe.base as pipeBase
         class FooTask(pipeBase.Task):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [flake8]
 max-line-length = 110
+max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
 exclude =
     __init__.py,

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -40,12 +40,14 @@ class TestConnectionsClass(unittest.TestCase):
         """Tests the declaration of a Connections Class
         """
         with pytest.raises(TypeError):
-            # This should raise because this Connections class is created with no dimensions
+            # This should raise because this Connections class is created with
+            # no dimensions
             class TestConnections(pipeBase.PipelineTaskConnections):
                 pass
 
         with pytest.raises(TypeError):
-            # This should raise because this Connections class is created with out template defaults
+            # This should raise because this Connections class is created with
+            # out template defaults
             class TestConnectionsTemplate(pipeBase.PipelineTaskConnections, dimensions=self.test_dims):
                 field = pipeBase.connectionTypes.Input(doc="Test", name="{template}test",
                                                        dimensions=self.test_dims,

--- a/tests/test_pipelineIR.py
+++ b/tests/test_pipelineIR.py
@@ -56,7 +56,8 @@ class ConfigIRTestCase(unittest.TestCase):
         # Merge configs with different dataIds, this should yield two elements
         self.assertEqual(list(config1.maybe_merge(config2)), [config1, config2])
 
-        # Merge configs with python blocks defined, this should yield two elements
+        # Merge configs with python blocks defined, this should yield two
+        # elements
         self.assertEqual(list(config1.maybe_merge(config3)), [config1, config3])
 
         # Merge configs with file defined, this should yield two elements
@@ -191,8 +192,8 @@ class PipelineIRTestCase(unittest.TestCase):
         pipeline = PipelineIR.from_string(pipeline_str)
         self.assertEqual(pipeline.contracts, [])
 
-        # Test that configs are inherited when defining the same task again with
-        # the same label
+        # Test that configs are inherited when defining the same task again
+        # with the same label
         pipeline_str = textwrap.dedent("""
         description: Test Pipeline
         inherits:

--- a/tests/test_showTasks.py
+++ b/tests/test_showTasks.py
@@ -64,7 +64,8 @@ c = MainTaskConfig()
 
 
 class ShowTasksTestCase(unittest.TestCase):
-    """A test case for the code that implements ArgumentParser's --show tasks option
+    """A test case for the code that implements ArgumentParser's --show tasks
+    option.
     """
 
     def testBasicShowTaskHierarchy(self):

--- a/tests/test_struct.py
+++ b/tests/test_struct.py
@@ -71,7 +71,8 @@ class StructTestCase(unittest.TestCase):
         sc = s.copy()
         self.assertEqual(s.getDict(), sc.getDict())
 
-        # shallow copy, so changing a list should propagate (not necessarily a feature)
+        # shallow copy, so changing a list should propagate (not necessarily a
+        # feature)
         sc.alist[0] = 97
         self.assertEqual(s, sc)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -131,7 +131,8 @@ class TaskTestCase(unittest.TestCase):
                 config = AddMultTask.ConfigClass()
                 config.add.addend = addend
                 config.mult["stdMult"].multiplicand = multiplicand
-                # make sure both ways of accessing the registry work and give the same result
+                # make sure both ways of accessing the registry work and give
+                # the same result
                 self.assertEqual(config.mult.active.multiplicand, multiplicand)
                 addMultTask = AddMultTask(config=config)
                 for val in (-1.0, 0.0, 17.5):

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -326,7 +326,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
                               {key: dataId for key in {"a", "b", "outA", "outB"}})
         runTestQuantum(task, self.butler, quantum, mockRun=False)
 
-        # Can we use runTestQuantum to verify that task.run got called with correct inputs/outputs?
+        # Can we use runTestQuantum to verify that task.run got called with
+        # correct inputs/outputs?
         self.assertTrue(self.butler.datasetExists("VisitOutA", dataId))
         self.assertEqual(self.butler.get("VisitOutA", dataId),
                          butlerTests.MetricsExample(data=(data["VisitA"] + data["VisitB"])))
@@ -347,7 +348,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         })
         runTestQuantum(task, self.butler, quantum, mockRun=False)
 
-        # Can we use runTestQuantum to verify that task.run got called with correct inputs/outputs?
+        # Can we use runTestQuantum to verify that task.run got called with
+        # correct inputs/outputs?
         inB = data["PatchB"][0][1]
         for dataset in data["PatchA"]:
             patchId = dataset[0]
@@ -365,7 +367,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
                               {key: dataId for key in {"a", "b", "outA", "outB"}})
         run = runTestQuantum(task, self.butler, quantum, mockRun=True)
 
-        # Can we use the mock to verify that task.run got called with the correct inputs?
+        # Can we use the mock to verify that task.run got called with the
+        # correct inputs?
         run.assert_called_once_with(a=butlerTests.MetricsExample(data=data["VisitA"]),
                                     b=butlerTests.MetricsExample(data=data["VisitB"]))
 
@@ -383,7 +386,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         })
         run = runTestQuantum(task, self.butler, quantum, mockRun=True)
 
-        # Can we use the mock to verify that task.run got called with the correct inputs?
+        # Can we use the mock to verify that task.run got called with the
+        # correct inputs?
         run.assert_called_once_with(
             a=[butlerTests.MetricsExample(data=dataset[1]) for dataset in data["PatchA"]],
             b=butlerTests.MetricsExample(data=data["PatchB"][0][1])
@@ -404,7 +408,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         })
         run = runTestQuantum(task, self.butler, quantum, mockRun=True)
 
-        # Can we use the mock to verify that task.run got called with the correct inputs?
+        # Can we use the mock to verify that task.run got called with the
+        # correct inputs?
         run.assert_called_once_with(
             a=[butlerTests.MetricsExample(data=dataset[1]) for dataset in data["PatchA"]]
         )


### PR DESCRIPTION
Use a factory unpickler in conjunction with a new method that
forms the keyword arguments to use in the constructor. This
allows subclasses to add additional parameters without requiring
they all implement a compatible reduce method.