### PR TITLE
DM-27941 Update import system

### DIFF
--- a/tests/testPipeline1.yaml
+++ b/tests/testPipeline1.yaml
@@ -7,3 +7,4 @@ tasks:
   modB: "test.moduleB"
 contracts:
   - modA.b == modA.c
+instrument: test.instrument


### PR DESCRIPTION
Change the name of the directive to import. Instruments are now
imported, and only one instrument may be defined among the
importing Pipeline, and all the imports.