### PR TITLE
DM-27462: Add --config-file option alias to CmdLineTask

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,10 +1,7 @@
-#!/usr/bin/env python
+from documenteer.conf.pipelinespkg import *  # noqa: F403, import *
 
-import lsst.pipe.base
-from documenteer.sphinxconfig.stackconf import build_package_configs
-
-
-_g = globals()
-_g.update(build_package_configs(
-    project_name='pipe_base',
-    version=lsst.pipe.base.version.__version__))
+project = "pipe_base"
+html_theme_options["logotext"] = project  # noqa: F405, unknown name
+html_title = project
+html_short_title = project
+doxylink = {}

--- a/doc/lsst.pipe.base/command-line-task-argument-reference.rst
+++ b/doc/lsst.pipe.base/command-line-task-argument-reference.rst
@@ -18,7 +18,7 @@ The basic call signature of a command-line task is:
 See :ref:`command-line-argument-files` for details on ``@file`` syntax.
 
 For named arguments that take multiple values do not use a ``=`` after the argument name.
-For example, ``--configfile foo.py bar.py``, **not** ``--configfile=foo bar``.
+For example, ``--config-file foo.py bar.py``, **not** ``--config-file=foo bar``.
 
 Status code
 ===========
@@ -72,11 +72,11 @@ Other named arguments are optional.
 
    See :ref:`command-line-task-config-howto-config` for more information.
 
-.. option:: -C <configfile>, --configfile <configfile>
+.. option:: -C <configfile>, --config-file <configfile>, --configfile <configfile>
 
    **Task configuration override file(s).**
 
-   The ``-C``/``--configfile`` argument can appear multiple times.
+   The ``-C``/``-config-file``/``--configfile`` argument can appear multiple times.
 
    See :ref:`command-line-task-config-howto-configfile` for more information.
 
@@ -305,7 +305,7 @@ For example, the file :file:`foo.txt` contains:
 .. code-block:: text
 
    --id visit=54123^55523 raft=1,1^2,1 # data ID
-   --config someParam=someValue --configfile configOverrideFilePath
+   --config someParam=someValue --config-file configOverrideFilePath
 
 You can then reference it with ``@foo.txt``, along with additional command-line arguments:
 

--- a/doc/lsst.pipe.base/command-line-task-config-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-config-howto.rst
@@ -5,7 +5,7 @@ Configuring command-line tasks
 ##############################
 
 :ref:`Command-line tasks <using-command-line-tasks>` are highly configurable.
-This page describes how to review configurations with :option:`--show config <--show>`,  and change configurations on the command line with :option:`--config` or :option:`--configfile`.
+This page describes how to review configurations with :option:`--show config <--show>`,  and change configurations on the command line with :option:`--config`, :option:`--config-file`, or :option:`--configfile`.
 
 One special category of configuration is subtask retargeting.
 Retargeting uses concepts discussed on this page, but with additional considerations described in :doc:`command-line-task-retargeting-howto`.
@@ -56,7 +56,7 @@ For example, this will show any configuration that includes the string ``calibra
 How to set configurations with command-line arguments
 =====================================================
 
-Command-line tasks can be configured through a combination of two mechanisms: arguments on the command line (:option:`--config`) or through configuration files (:option:`--configfile`).
+Command-line tasks can be configured through a combination of two mechanisms: arguments on the command line (:option:`--config`) or through configuration files (:option:`--config-file` or :option:`--configfile`).
 In general, simple configurations can be made through the command line, while complex configurations and :ref:`subtask retargeting <command-line-task-retargeting-howto>` must done through configuration files (see :ref:`command-line-task-config-howto-configfile`).
 
 To change a configuration value on the command line, pass that configuration name and value to the :option:`--config` argument.
@@ -102,13 +102,13 @@ In fact, configuration files are Python modules; anything you can do in Python y
 Configuration files give you full access to the configuration API, allowing you to import and :doc:`retarget subtasks <command-line-task-retargeting-howto>`, and set configurations with complex types.
 These configurations can only be done through configuration files, not through command-line arguments.
 
-Use a configuration file by providing its file path through a :option:`-C`/:option:`--configfile` argument:
+Use a configuration file by providing its file path through a :option:`-C`/:option:`--config-file`/:option:`--configfile` argument:
 
 .. code-block:: bash
 
-   task.py REPOPATH --output output --configfile taskConfig.py
+   task.py REPOPATH --output output --config-file taskConfig.py
 
-Multiple configuration files can be provided through the same :option:`--configfile` argument and the :option:`--configfile` argument itself can be repeated.
+Multiple configuration files can be provided through the same :option:`--config-file` argument and the :option:`--config-file` argument itself can be repeated.
 
 In a configuration file, configurations are attributes of a ``config`` object.
 If on the command line you set a configuration with a ``--config skyMap.projection="TAN"`` argument, in a configuration file the equivalent statement is:
@@ -143,7 +143,7 @@ Here are two examples:
 
 Overall, the priority order for setting task configurations is configurations is (highest priority first):
 
-1. User-provided :option:`--config` and :option:`--configfile` arguments (computed left-to-right).
+1. User-provided :option:`--config` and :option:`--config-file` arguments (computed left-to-right).
 2. Camera specific configuration override file in an observatory package.
 3. General configuration override file in an observatory package.
 4. Task defaults.

--- a/doc/lsst.pipe.base/command-line-task-retargeting-howto.rst
+++ b/doc/lsst.pipe.base/command-line-task-retargeting-howto.rst
@@ -56,7 +56,7 @@ Note that if the ``calibrate.astrometry`` task is retargeted to a different task
 How to retarget a subtask configured as a ConfigurableField with a configuration file
 =====================================================================================
 
-To retarget a subtask specified as an `lsst.pex.config.ConfigurableField`, you must use a configuration file (specified by :option:`--configfile`, see :ref:`command-line-task-config-howto-configfile`).
+To retarget a subtask specified as an `lsst.pex.config.ConfigurableField`, you must use a configuration file (specified by :option:`--config-file` or :option:`--configfile`, see :ref:`command-line-task-config-howto-configfile`).
 Inside a configuration file, retargeting is done in two steps:
 
 1. Import the Task class you intend to use.
@@ -88,7 +88,7 @@ For example:
 How to retarget a subtask configured as a RegistryField with a configuration file
 =================================================================================
 
-To retarget a subtask specified as an `lsst.pex.config.RegistryField`, set the field's `~lsst.pex.config.RegistryField.name` attribute in a configuration file (using :option:`--configfile`).
+To retarget a subtask specified as an `lsst.pex.config.RegistryField`, set the field's `~lsst.pex.config.RegistryField.name` attribute in a configuration file (using :option:`--config-file` or :option:`--configfile`).
 Here is an example that assumes a task ``FooTask`` is defined in module :file:`.../foo.py` and registered using name ``foo``:
 
 .. code-block:: python

--- a/doc/lsst.pipe.base/creating-a-task.rst
+++ b/doc/lsst.pipe.base/creating-a-task.rst
@@ -351,7 +351,7 @@ There are advantages to each:
 
        config.registrySubtask.name = "foo"
 
-    By comparison, a subtask specified as an `lsst.pex.config.ConfigurableField` can only be retargeted from a config override file (e.g. using :option:`--configfile`, never :option:`--config`):
+    By comparison, a subtask specified as an `lsst.pex.config.ConfigurableField` can only be retargeted from a config override file (e.g. using :option:`--config-file`, never :option:`--config`):
 
     .. code-block:: python
 

--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -439,15 +439,15 @@ class ArgumentParser(argparse.ArgumentParser):
                                          usage=usage,
                                          fromfile_prefix_chars='@',
                                          epilog=textwrap.dedent("""Notes:
-            * --config, --configfile, --id, --loglevel and @file may appear multiple times;
+            * --config, --config-file or --configfile, --id, --loglevel and @file may appear multiple times;
                 all values are used, in order left to right
             * @file reads command-line options from the specified file:
                 * data may be distributed among multiple lines (e.g. one option per line)
                 * data after # is treated as a comment and ignored
                 * blank lines and lines starting with # are ignored
             * To specify multiple values for an option, do not use = after the option name:
-                * right: --configfile foo bar
-                * wrong: --configfile=foo bar
+                * right: --config-file foo bar
+                * wrong: --config-file=foo bar
             """),
                                          formatter_class=argparse.RawDescriptionHelpFormatter,
                                          **kwargs)
@@ -463,7 +463,8 @@ class ArgumentParser(argparse.ArgumentParser):
                                "optionally sets ROOT to ROOT/rerun/INPUT")
         self.add_argument("-c", "--config", nargs="*", action=ConfigValueAction,
                           help="config override(s), e.g. -c foo=newfoo bar.baz=3", metavar="NAME=VALUE")
-        self.add_argument("-C", "--configfile", dest="configfile", nargs="*", action=ConfigFileAction,
+        self.add_argument("-C", "--config-file", "--configfile",
+                          dest="configfile", nargs="*", action=ConfigFileAction,
                           help="config override file(s)")
         self.add_argument("-L", "--loglevel", nargs="*", action=LogLevelAction,
                           help="logging level; supported levels are [trace|debug|info|warn|error|fatal]",


### PR DESCRIPTION
This PR adds `--config-file` (the keyword used in Gen 3) as an alias to `--configfile` for `CmdLineTasks`, then updates the documentation to favor the former. This should reduce the learning curve for new Science Pipelines users during the transition. No attempt is made to remove or deprecate references to `--configfile`.