### PR TITLE
DM-23156: Add ways to test a PipelineTask's init inputs/outputs

### DIFF
--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -48,18 +48,17 @@ Such a test can be combined with separate unit tests of how `~lsst.pipe.base.Pip
 If you do need `~lsst.pipe.base.PipelineTask.runQuantum` to call `~lsst.pipe.base.PipelineTask.run` (for example, because the test needs real outputs written to the repository), setting the ``mockRun=False`` argument will restore the normal behavior.
 
 .. code-block:: py
-   :emphasize-lines: 20-29
+   :emphasize-lines: 19-28
 
    import lsst.daf.butler.tests as butlerTests
    from lsst.pipe.base import testUtils
 
    # A minimal Butler repo, see daf_butler documentation
-   dimensions = {
-       "instrument": ["notACam"],
-       "visit": [101, 102],
-       "detector": [42],
-   }
-   repo = butlerTests.makeTestRepo(tempDir, dimensions)
+   repo = butlerTests.makeTestRepo(tempDir)
+   butlerTests.addDataIdValue(repo, "instrument", "notACam")
+   butlerTests.addDataIdValue(repo, "visit", 101)
+   butlerTests.addDataIdValue(repo, "visit", 102)
+   butlerTests.addDataIdValue(repo, "detector", 42)
    butlerTests.addDatasetType(
        repo, "InputType", {"instrument", "visit", "detector"},
        "ExposureF")

--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -178,6 +178,9 @@ The logic that activates or deactivates inputs is normally found in the `~lsst.p
 Input-selecting logic can be tested by calling `lsst.pipe.base.testUtils.runTestQuantum` and checking which arguments were passed to `~lsst.pipe.base.PipelineTask.run`.
 Output-selecting logic can be tested with `lsst.pipe.base.testUtils.verifyOutputConnections`.
 
+Optional init-inputs can be tested by calling `lsst.pipe.base.testUtils.getInitInputs` and checking which values are returned.
+There is currently no test framework for the use of init-inputs in task constructors.
+
 .. code-block:: py
    :emphasize-lines: 42-43, 49-50
 

--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -124,6 +124,49 @@ Currently, it tests for missing fields and mixing up vector and scalar values; m
    # raises because result.catalog does not exist
    testUtils.assertValidOutput(task, result)
 
+.. _testing-a-pipeline-task-initOutput:
+
+Testing task initOutputs
+========================
+
+If a pipeline task has initOutputs, task objects must have one attribute for each such output.
+
+The `lsst.pipe.base.testUtils.assertValidInitOutput` function takes a task object and confirms that it has an attribute for each initOutput in its connections.
+The tests are analogous to :ref:`those for assertValidOutput <testing-a-pipeline-task-run-output>`.
+
+.. code-block:: py
+   :emphasize-lines: 28-29
+
+   import lsst.afw.table as afwTable
+   import lsst.daf.butler.tests as butlerTests
+   from lsst.pipe.base import connectionTypes, PipelineTask, \
+       PipelineTaskConnections
+   from lsst.pipe.base import testUtils
+
+
+   class MyConnections(
+           PipelineTaskConnections,
+           dimensions=("instrument", "visit", "detector")):
+       schema = connectionTypes.InitOutput(
+           name="srcSchema",
+           storageClass="SourceCatalog")
+       catalog = connectionTypes.Output(
+           name="src",
+           storageClass="SourceCatalog",
+           dimensions=("instrument", "visit", "detector"))
+
+
+   class MyTask(PipelineTask):
+       def __init__(config=None, log=None, initInputs=None):
+           super().__init__(config, log, initInputs)
+           # bug: should be SourceCatalog
+           self.schema = afwTable.Schema()
+
+
+   task = MyTask()
+   # raises because result.schema has wrong type
+   testUtils.assertValidInitOutput(task)
+
 .. _testing-a-pipeline-task-optional-connections:
 
 Testing optional/alternative inputs/outputs

--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -176,7 +176,7 @@ Some tasks change their inputs depending on what processing is to be done (for e
 The logic that activates or deactivates inputs is normally found in the `~lsst.pipe.base.PipelineTaskConnections` class's constructor.
 
 Input-selecting logic can be tested by calling `lsst.pipe.base.testUtils.runTestQuantum` and checking which arguments were passed to `~lsst.pipe.base.PipelineTask.run`.
-Output-selecting logic can be tested with `lsst.pipe.base.testUtils.verifyOutputConnections`.
+Output-selecting logic can be tested with `lsst.pipe.base.testUtils.assertValidOutput`.
 
 Optional init-inputs can be tested by calling `lsst.pipe.base.testUtils.getInitInputs` and checking which values are returned.
 There is currently no test framework for the use of init-inputs in task constructors.

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-__all__ = ["makeQuantum", "runTestQuantum", "assertValidOutput"]
+__all__ = ["makeQuantum", "runTestQuantum", "assertValidOutput", "assertValidInitOutput"]
 
 
 from collections import defaultdict
@@ -305,3 +305,24 @@ def assertValidOutput(task, result):
     for name in connections.outputs:
         connection = connections.__getattribute__(name)
         _assertAttributeMatchesConnection(result, name, connection)
+
+
+def assertValidInitOutput(task):
+    """Test that a constructed task conforms to its own init-connections.
+
+    Parameters
+    ----------
+    task : `lsst.pipe.base.PipelineTask`
+        The task whose connections need validation.
+
+    Raises
+    ------
+    AssertionError:
+        Raised if ``task`` does not have the state expected from ``task's``
+        connections.
+    """
+    connections = task.config.ConnectionsClass(config=task.config)
+
+    for name in connections.initOutputs:
+        connection = connections.__getattribute__(name)
+        _assertAttributeMatchesConnection(task, name, connection)

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -20,7 +20,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-__all__ = ["makeQuantum", "runTestQuantum", "assertValidOutput", "assertValidInitOutput", "getInitInputs"]
+__all__ = ["assertValidInitOutput",
+           "assertValidOutput",
+           "getInitInputs",
+           "makeQuantum",
+           "runTestQuantum",
+           ]
 
 
 from collections import defaultdict

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -261,14 +261,13 @@ def assertValidOutput(task, result):
         connections.
     """
     connections = task.config.ConnectionsClass(config=task.config)
-    recoveredOutputs = result.getDict()
 
     for name in connections.outputs:
         connection = connections.__getattribute__(name)
         # name
         try:
-            output = recoveredOutputs[name]
-        except KeyError:
+            output = result.__getattribute__(name)
+        except AttributeError:
             raise AssertionError(f"No such output: {name}")
         # multiple
         if connection.multiple:

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -153,15 +153,14 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         # this has a prohibitive run-time cost at present
         cls.root = tempfile.mkdtemp()
 
-        dataIds = {
-            "instrument": ["notACam"],
-            "physical_filter": ["k2020"],  # needed for expandUniqueId(visit)
-            "visit": [101, 102],
-            "skymap": ["sky"],
-            "tract": [42],
-            "patch": [0, 1],
-        }
-        cls.repo = butlerTests.makeTestRepo(cls.root, dataIds)
+        cls.repo = butlerTests.makeTestRepo(cls.root)
+        butlerTests.addDataIdValue(cls.repo, "instrument", "notACam")
+        butlerTests.addDataIdValue(cls.repo, "visit", 101)
+        butlerTests.addDataIdValue(cls.repo, "visit", 102)
+        butlerTests.addDataIdValue(cls.repo, "skymap", "sky")
+        butlerTests.addDataIdValue(cls.repo, "tract", 42)
+        butlerTests.addDataIdValue(cls.repo, "patch", 0)
+        butlerTests.addDataIdValue(cls.repo, "patch", 1)
         butlerTests.registerMetricsExample(cls.repo)
 
         for typeName in {"VisitA", "VisitB", "VisitOutA", "VisitOutB"}:
@@ -242,7 +241,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         config.connections.a = "Visit"
         task = VisitTask(config=config)
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
+        dataId = {"instrument": "notACam", "visit": 102}
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
@@ -252,8 +251,8 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         config = VisitConfig()
         config.connections.a = "PatchA"
         task = VisitTask(config=config)
-        dataIdV = butlerTests.expandUniqueId(self.butler, {"visit": 102})
-        dataIdP = butlerTests.expandUniqueId(self.butler, {"patch": 0})
+        dataIdV = {"instrument": "notACam", "visit": 102}
+        dataIdP = {"skymap": "sky", "tract": 42, "patch": 0}
 
         inA = [1, 2, 3]
         inB = [4, 0, 1]
@@ -272,7 +271,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testMakeQuantumMissingMultiple(self):
         task = PatchTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
+        dataId = {"skymap": "sky", "tract": 42}
         self._makePatchTestData(dataId)
 
         with self.assertRaises(ValueError):
@@ -285,7 +284,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testMakeQuantumExtraMultiple(self):
         task = PatchTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
+        dataId = {"skymap": "sky", "tract": 42}
         self._makePatchTestData(dataId)
 
         with self.assertRaises(ValueError):
@@ -298,7 +297,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testMakeQuantumMissingDataId(self):
         task = VisitTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
+        dataId = {"instrument": "notACam", "visit": 102}
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
@@ -309,7 +308,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testMakeQuantumCorruptedDataId(self):
         task = VisitTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
+        dataId = {"instrument": "notACam", "visit": 102}
         self._makeVisitTestData(dataId)
 
         with self.assertRaises(ValueError):
@@ -319,7 +318,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testRunTestQuantumVisitWithRun(self):
         task = VisitTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
+        dataId = {"instrument": "notACam", "visit": 102}
         data = self._makeVisitTestData(dataId)
 
         quantum = makeQuantum(task, self.butler, dataId,
@@ -338,7 +337,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testRunTestQuantumPatchWithRun(self):
         task = PatchTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
+        dataId = {"skymap": "sky", "tract": 42}
         data = self._makePatchTestData(dataId)
 
         quantum = makeQuantum(task, self.butler, dataId, {
@@ -360,7 +359,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testRunTestQuantumVisitMockRun(self):
         task = VisitTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"visit": 102})
+        dataId = {"instrument": "notACam", "visit": 102}
         data = self._makeVisitTestData(dataId)
 
         quantum = makeQuantum(task, self.butler, dataId,
@@ -375,7 +374,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
     def testRunTestQuantumPatchMockRun(self):
         task = PatchTask()
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
+        dataId = {"skymap": "sky", "tract": 42}
         data = self._makePatchTestData(dataId)
 
         quantum = makeQuantum(task, self.butler, dataId, {
@@ -398,7 +397,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         config.doUseB = False
         task = PatchTask(config=config)
 
-        dataId = butlerTests.expandUniqueId(self.butler, {"tract": 42})
+        dataId = {"skymap": "sky", "tract": 42}
         data = self._makePatchTestData(dataId)
 
         quantum = makeQuantum(task, self.butler, dataId, {


### PR DESCRIPTION
This PR adds utilities to `testUtils` for testing a `PipelineTask`'s init-outputs. There is some support for init-inputs as well, but it's no better than the existing support for inputs. There are also some minor changes to bring the test code and documentation in line with lsst/daf_butler#465.