### PR TITLE
DM-29255 Modify applying config overrides for flexibility

### DIFF
--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -194,8 +194,8 @@ def makeSimplePipeline(nQuanta, instrument=None):
     # dependencies)
     for lvl in range(nQuanta):
         pipeline.addTask(AddTask, f"task{lvl}")
-        pipeline.addConfigOverride(f"task{lvl}", "connections.in_tmpl", f"{lvl}")
-        pipeline.addConfigOverride(f"task{lvl}", "connections.out_tmpl", f"{lvl+1}")
+        pipeline.addConfigOverride(f"task{lvl}", "connections.in_tmpl", lvl)
+        pipeline.addConfigOverride(f"task{lvl}", "connections.out_tmpl", lvl+1)
     if instrument:
         pipeline.addInstrument(instrument)
     return pipeline


### PR DESCRIPTION
These changes allow greater flexibility when doing config overrieds
in areas such as not needing string escaping when working with the
command line, and using values from python statements in other
parts of pipeline config blocks.