### PR TITLE
DM-29388 Treat strings that cant be parsed as strings

### DIFF
--- a/python/lsst/pipe/base/configOverrides.py
+++ b/python/lsst/pipe/base/configOverrides.py
@@ -27,7 +27,6 @@ __all__ = ["ConfigOverrides"]
 import ast
 from operator import attrgetter
 
-import lsst.pex.exceptions as pexExceptions
 from lsst.utils import doImport
 
 import inspect
@@ -202,10 +201,13 @@ class ConfigOverrides:
     def _parser(self, value, configParser):
         try:
             value = configParser.visit(ast.parse(value, mode='eval').body)
-        except ValueError:
-            # eval failed, wrap exception with more user-friendly
-            # message
-            raise pexExceptions.RuntimeError(f"Unable to parse `{value}' into a Python object") from None
+        except Exception:
+            # This probably means it is a specific user string such as a URI.
+            # Let the value return as a string to attempt to continue to
+            # process as a string, another error will be raised in downstream
+            # code if that assumption is wrong
+            pass
+
         return value
 
     def applyTo(self, config):


### PR DESCRIPTION
When trying to apply config overrides, if a string cant be turned
into some other python expression, or object, leave it as a string.
If this assumption is bad, it will allow the config field to raise
its own exception.