### PR TITLE
DM-19634: Handle --longlog when seen.

### DIFF
--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -469,7 +469,7 @@ class ArgumentParser(argparse.ArgumentParser):
         self.add_argument("-L", "--loglevel", nargs="*", action=LogLevelAction,
                           help="logging level; supported levels are [trace|debug|info|warn|error|fatal]",
                           metavar="LEVEL|COMPONENT=LEVEL")
-        self.add_argument("--longlog", action="store_true", help="use a more verbose format for the logging")
+        self.add_argument("--longlog", action=LongLogAction, help="use a more verbose format for the logging")
         self.add_argument("--debug", action="store_true", help="enable debugging output?")
         self.add_argument("--doraise", action="store_true",
                           help="raise an exception on error (else log a message and continue)?")
@@ -711,15 +711,6 @@ log4j.appender.A1.layout.ConversionPattern=%c %p: %m%n
                 namespace.debug = False
 
         del namespace.loglevel
-
-        if namespace.longlog:
-            lsstLog.configure_prop("""
-log4j.rootLogger=INFO, A1
-log4j.appender.A1=ConsoleAppender
-log4j.appender.A1.Target=System.out
-log4j.appender.A1.layout=PatternLayout
-log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c (%X{LABEL})(%F:%L)- %m%n
-""")
         del namespace.longlog
 
         namespace.config.validate()
@@ -1250,6 +1241,35 @@ class IdValueAction(argparse.Action):
         argName = option_string.lstrip("-")
         ident = getattr(namespace, argName)
         ident.idList += idDictList
+
+
+class LongLogAction(argparse.Action):
+    """argparse action to make logs verbose.
+
+    An action so that it can take effect before log level options.
+    """
+
+    def __call__(self, parser, namespace, values, option_string):
+        """Set long log.
+
+        Parameters
+        ----------
+        parser : `ArgumentParser`
+            Argument parser.
+        namespace : `argparse.Namespace`
+            Parsed command. This argument is not used.
+        values : `list`
+            Unused.
+        option_string : `str`
+            Option value specified by the user (unused).
+        """
+        lsstLog.configure_prop("""
+log4j.rootLogger=INFO, A1
+log4j.appender.A1=ConsoleAppender
+log4j.appender.A1.Target=System.out
+log4j.appender.A1.layout=PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-5p %d{yyyy-MM-ddTHH:mm:ss.SSSZ} %c (%X{LABEL})(%F:%L)- %m%n
+""")
 
 
 class LogLevelAction(argparse.Action):


### PR DESCRIPTION
Since this Gen2 code will be going away, I took a more expeditious route of handling `--longlog` when seen in the command line, so it will take effect before `--loglevel` options that come after (but still override those that come before).