### PR TITLE
DM-30061: PipelineTasks do not use pipeline label as name

### DIFF
--- a/python/lsst/pipe/base/taskFactory.py
+++ b/python/lsst/pipe/base/taskFactory.py
@@ -35,13 +35,16 @@ class TaskFactory(metaclass=ABCMeta):
     """
 
     @abstractmethod
-    def makeTask(self, taskClass, config, overrides, butler):
+    def makeTask(self, taskClass, name, config, overrides, butler):
         """Create new PipelineTask instance from its class.
 
         Parameters
         ----------
         taskClass : `type`
             `PipelineTask` sub-class.
+        name : `str` or `None`
+            The name of the new task; if `None` then use
+            ``taskClass._DefaultName``.
         config : `pex.Config` or `None`
             Configuration object, if `None` then use task-defined
             configuration class (``taskClass.ConfigClass``) to create new

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -124,12 +124,12 @@ class AddTaskFactoryMock(pipeBase.TaskFactory):
         if taskName == "AddTask":
             return AddTask, "AddTask"
 
-    def makeTask(self, taskClass, config, overrides, butler):
+    def makeTask(self, taskClass, name, config, overrides, butler):
         if config is None:
             config = taskClass.ConfigClass()
             if overrides:
                 overrides.applyTo(config)
-        task = taskClass(config=config, initInputs=None)
+        task = taskClass(config=config, initInputs=None, name=name)
         task.taskFactory = self
         return task
 


### PR DESCRIPTION
This PR updates `TaskFactory.makeTask` to take a label argument, and updates all internal references.

I suspect it would be better for `makeTask` to take a `TaskDef` rather than a specific list of internals, but don't want to make such a fundamental change on this ticket.