### PR TITLE
DM-28668: PipelineTask unit test framework bypasses dimensions checks

### DIFF
--- a/doc/lsst.pipe.base/testing-a-pipeline-task.rst
+++ b/doc/lsst.pipe.base/testing-a-pipeline-task.rst
@@ -234,3 +234,29 @@ There is currently no test framework for the use of init-inputs in task construc
    task = OrTask(config=config)
    run = testUtils.runTestQuantum(task, butler, quantum)
    run.assert_called_once_with(cat=testCatalog)
+
+.. _testing-a-pipeline-task-static-analysis:
+
+Analyzing Connections Classes
+=============================
+
+Mistakes in creating pipeline connections classes can lead to hard-to-debug errors at run time.
+The `lsst.pipe.base.testUtils.lintConnections` function analyzes a connections class for common errors.
+The only errors currently tested are those involving inconsistencies between connection and quantum dimensions.
+
+All tests done by `lintConnections` are heuristic, looking for common patterns of misuse.
+Advanced users who are *deliberately* bending the usual rules can use keywords to turn off specific tests.
+
+.. code-block:: py
+   :emphasize-lines: 9-10
+
+   class ListConnections(PipelineTaskConnections,
+                         dimensions=("instrument", "visit", "detector")):
+       cat = connectionTypes.Input(
+           name="src",
+           storageClass="SourceCatalog",
+           dimensions=("instrument", "visit", "detector"),
+           multiple=True)  # force a list of one catalog
+
+   lintConnections(ListConnections)  # warns that cat always has one input
+   lintConnections(ListConnections, checkUnnecessaryMultiple=False)  # passes

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -267,6 +267,10 @@ class PipelineTaskConnections(metaclass=PipelineTaskConnectionsMetaclass):
         A `PipelineTaskConfig` class instance whose class has been configured
         to use this `PipelineTaskConnectionsClass`
 
+    See also
+    --------
+    iterConnections
+
     Notes
     -----
     ``PipelineTaskConnection`` classes are created by declaring class

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -302,9 +302,17 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         self.butler.put(butlerTests.MetricsExample(data=inA), "PatchA", dataIdP)
         self.butler.put(butlerTests.MetricsExample(data=inB), "VisitB", dataIdV)
 
+        # dataIdV is correct everywhere, dataIdP should error
         with self.assertRaises(ValueError):
             makeQuantum(task, self.butler, dataIdV, {
                 "a": dataIdP,
+                "b": dataIdV,
+                "outA": dataIdV,
+                "outB": dataIdV,
+            })
+        with self.assertRaises(ValueError):
+            makeQuantum(task, self.butler, dataIdP, {
+                "a": dataIdV,
                 "b": dataIdV,
                 "outA": dataIdV,
                 "outB": dataIdV,

--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -294,6 +294,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
         config.connections.a = "PatchA"
         task = VisitTask(config=config)
         dataIdV = {"instrument": "notACam", "visit": 102}
+        dataIdVExtra = {"instrument": "notACam", "visit": 102, "detector": 42}
         dataIdP = {"skymap": "sky", "tract": 42, "patch": 0}
 
         inA = [1, 2, 3]
@@ -312,6 +313,21 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
             })
         with self.assertRaises(ValueError):
             makeQuantum(task, self.butler, dataIdP, {
+                "a": dataIdV,
+                "b": dataIdV,
+                "outA": dataIdV,
+                "outB": dataIdV,
+            })
+        # should not accept small changes, either
+        with self.assertRaises(ValueError):
+            makeQuantum(task, self.butler, dataIdV, {
+                "a": dataIdV,
+                "b": dataIdV,
+                "outA": dataIdVExtra,
+                "outB": dataIdV,
+            })
+        with self.assertRaises(ValueError):
+            makeQuantum(task, self.butler, dataIdVExtra, {
                 "a": dataIdV,
                 "b": dataIdV,
                 "outA": dataIdV,


### PR DESCRIPTION
This PR tries to catch connections dimension errors by checking that supplied data IDs in testing match the connections (on the assumption that a mismatch might mean the connections aren't what the test author expected) and by providing a separate function for detecting common errors.