### PR TITLE
DM-31251: Use "auto" mode when importing to execution butler

### DIFF
--- a/python/lsst/pipe/base/executionButlerBuilder.py
+++ b/python/lsst/pipe/base/executionButlerBuilder.py
@@ -187,7 +187,7 @@ def _import(yamlBuffer: io.StringIO,
     # that are expected to be produced.
 
     # import the existing datasets
-    newButler.import_(filename=yamlBuffer, format="yaml", reuseIds=True)
+    newButler.import_(filename=yamlBuffer, format="yaml", reuseIds=True, transfer="auto")
 
     # If there is modifier callable, run it to make necessary updates
     # to the new butler.


### PR DESCRIPTION
This allows the new "split" mode to be picked up.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
