### PR TITLE
DM-27492: Add support for skip-existing-in option

### DIFF
--- a/doc/changes/DM-27492.api.md
+++ b/doc/changes/DM-27492.api.md
@@ -1,0 +1,3 @@
+`GraphBuilder` constructor boolean argument `skipExisting` is replaced with
+`skipExistingIn` which accepts collections to check for existing quantum
+outputs.

--- a/python/lsst/pipe/base/pipeTools.py
+++ b/python/lsst/pipe/base/pipeTools.py
@@ -39,24 +39,6 @@ from .connections import iterConnections
 #  Local non-exported definitions --
 # ----------------------------------
 
-
-def _loadTaskClass(taskDef, taskFactory):
-    """Import task class if necessary.
-
-    Raises
-    ------
-    `ImportError` is raised when task class cannot be imported.
-    `MissingTaskFactoryError` is raised when TaskFactory is needed but not
-    provided.
-    """
-    taskClass = taskDef.taskClass
-    if not taskClass:
-        if not taskFactory:
-            raise MissingTaskFactoryError("Task class is not defined but task "
-                                          "factory instance is not provided")
-        taskClass = taskFactory.loadTaskClass(taskDef.taskName)
-    return taskClass
-
 # ------------------------
 #  Exported definitions --
 # ------------------------

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -304,7 +304,7 @@ def populateButler(pipeline, butler, datasetTypes=None):
 
 
 def makeSimpleQGraph(nQuanta=5, pipeline=None, butler=None, root=None, run="test",
-                     skipExisting=False, inMemory=True, userQuery="",
+                     skipExistingIn=None, inMemory=True, userQuery="",
                      datasetTypes=None):
     """Make simple QuantumGraph for tests.
 
@@ -328,9 +328,10 @@ def makeSimpleQGraph(nQuanta=5, pipeline=None, butler=None, root=None, run="test
     run : `str`, optional
         Name of the RUN collection to add to butler, only used if ``butler``
         is None.
-    skipExisting : `bool`, optional
-        If `True` (default), a Quantum is not created if all its outputs
-        already exist.
+    skipExistingIn
+        Expressions representing the collections to search for existing
+        output datasets that should be skipped.  May be any of the types
+        accepted by `lsst.daf.butler.CollectionSearch.fromExpression`.
     inMemory : `bool`, optional
         If true make in-memory repository, only used if ``butler`` is `None`.
     userQuery : `str`, optional
@@ -359,8 +360,8 @@ def makeSimpleQGraph(nQuanta=5, pipeline=None, butler=None, root=None, run="test
     populateButler(pipeline, butler, datasetTypes=datasetTypes)
 
     # Make the graph
-    _LOG.debug("Instantiating GraphBuilder, skipExisting=%s", skipExisting)
-    builder = pipeBase.GraphBuilder(registry=butler.registry, skipExisting=skipExisting)
+    _LOG.debug("Instantiating GraphBuilder, skipExistingIn=%s", skipExistingIn)
+    builder = pipeBase.GraphBuilder(registry=butler.registry, skipExistingIn=skipExistingIn)
     _LOG.debug("Calling GraphBuilder.makeGraph, collections=%r, run=%r, userQuery=%r",
                butler.collections, run or butler.run, userQuery)
     qgraph = builder.makeGraph(

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -120,10 +120,6 @@ class AddTaskFactoryMock(pipeBase.TaskFactory):
         self.countExec = 0  # incremented by AddTask
         self.stopAt = stopAt  # AddTask raises exception at this call to run()
 
-    def loadTaskClass(self, taskName):
-        if taskName == "AddTask":
-            return AddTask, "AddTask"
-
     def makeTask(self, taskClass, name, config, overrides, butler):
         if config is None:
             config = taskClass.ConfigClass()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -27,7 +27,8 @@ import unittest
 
 import lsst.pex.config as pexConfig
 from lsst.pipe.base import (Struct, PipelineTask, PipelineTaskConfig, Pipeline, TaskDef,
-                            PipelineTaskConnections)
+                            PipelineTaskConnections, PipelineDatasetTypes)
+from lsst.pipe.base.tests.simpleQGraph import makeSimplePipeline
 import lsst.utils.tests
 
 
@@ -151,6 +152,27 @@ class TaskTestCase(unittest.TestCase):
         dump = str(pipeline)
         load = Pipeline.fromString(dump)
         self.assertEqual(pipeline, load)
+
+
+class PipelineTestCase(unittest.TestCase):
+    """Test case for Pipeline and related classes
+    """
+
+    def test_initOutputNames(self):
+        """Test for PipelineDatasetTypes.initOutputNames method.
+        """
+        pipeline = makeSimplePipeline(3)
+        dsType = set(PipelineDatasetTypes.initOutputNames(pipeline))
+        expected = {
+            "packages",
+            "add_init_output1",
+            "add_init_output2",
+            "add_init_output3",
+            "task0_config",
+            "task1_config",
+            "task2_config",
+        }
+        self.assertEqual(dsType, expected)
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
`GraphBuilder` constructor boolean argument `skipExisting` is replaced with
`skipExistingIn` which accepts collections to check for existing quantum
outputs.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
