### PR TITLE
DM-31583: log new butler query diagnostics when QG is empty

### DIFF
--- a/doc/changes/DM-31583.feature.rst
+++ b/doc/changes/DM-31583.feature.rst
@@ -1,0 +1,3 @@
+Log diagnostic information when QuantumGraphs are empty because the initial query yielded no results.
+
+At present, these diagnostics only cover missing input datasets, which is a common way to get an empty QuantumGraph, but not the only way.

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -30,6 +30,7 @@ __all__ = [
     "InputQuantizedConnection",
     "OutputQuantizedConnection",
     "PipelineTaskConnections",
+    "ScalarError",
     "iterConnections",
 ]
 

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -579,6 +579,9 @@ class _PipelineScaffolding:
                     for datasetType in task.outputs:
                         ref = refsForRow[datasetType.name]
                         quantum.outputs[datasetType.name][ref.dataId] = ref
+            if n == 0:
+                for message in commonDataIds.explain_no_results():
+                    _LOG.warn(message)
             _LOG.debug("Finished processing %d rows from data ID query.", n)
             yield commonDataIds
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
