### PR TITLE
DM-31801: Prepend Task loggers with "lsst"

### DIFF
--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -61,7 +61,7 @@ from ._datasetQueryConstraints import DatasetQueryConstraintVariant
 #  Local non-exported definitions --
 # ----------------------------------
 
-_LOG = logging.getLogger(__name__.partition(".")[2])
+_LOG = logging.getLogger(__name__)
 
 
 class _DatasetDict(NamedKeyDict[DatasetType, Dict[DataCoordinate, DatasetRef]]):

--- a/python/lsst/pipe/base/task.py
+++ b/python/lsst/pipe/base/task.py
@@ -139,6 +139,10 @@ class Task:
     `~lsst.pipe.base.CmdLineTask` not Task.
     """
 
+    _add_module_logger_prefix = True
+    """Control whether the module prefix should be prepended to default
+    logger names."""
+
     def __init__(self, config=None, name=None, parentTask=None, log=None):
         self.metadata = dafBase.PropertyList()
         self.__parentTask: Optional[weakref.ReferenceType]
@@ -167,6 +171,17 @@ class Task:
             loggerName = self._fullName
             if log is not None and log.name:
                 loggerName = log.getChild(loggerName).name
+            elif self._add_module_logger_prefix:
+                # Prefix the logger name with the root module name.
+                # We want all Task loggers to have this prefix to make
+                # it easier to control them. This can be disabled by
+                # a Task setting the class property _add_module_logger_prefix
+                # to False -- in which case the logger name will not be
+                # modified.
+                module_name = self.__module__
+                module_root = module_name.split(".")[0] + "."
+                if not loggerName.startswith(module_root):
+                    loggerName = module_root + loggerName
 
         # Get a logger (that might be a subclass of logging.Logger).
         self.log = lsst.utils.logging.getLogger(loggerName)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -75,6 +75,7 @@ class AddMultConfig(pexConfig.Config):
 class AddMultTask(pipeBase.Task):
     ConfigClass = AddMultConfig
     _DefaultName = "addMult"
+    _add_module_logger_prefix = False
 
     """First add, then multiply"""
 
@@ -104,6 +105,11 @@ class AddMultTask(pipeBase.Task):
         """
         with self.timer("failCtx"):
             raise RuntimeError("failCtx intentional error")
+
+
+class AddMultTask2(AddMultTask):
+    """Subclass that gets an automatic logger prefix."""
+    _add_module_logger_prefix = True
 
 
 class AddTwiceTask(AddTask):
@@ -171,6 +177,9 @@ class TaskTestCase(unittest.TestCase):
         addMultTask = AddMultTask(log=log)
         self.assertEqual(addMultTask.log.name, "tester.addMult")
         self.assertEqual(addMultTask.add.log.name, "tester.addMult.add")
+
+        addMultTask2 = AddMultTask2()
+        self.assertEqual(addMultTask2.log.name, "test_task.addMult")
 
     def testGetFullMetadata(self):
         """Test getFullMetadata()


### PR DESCRIPTION
This allows all Task loggers by default to be in the same logger hierarchy.

The code does not hard-code "lsst" but determines the prefix from the Task `__module__` name.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
