### PR TITLE
DM-32226: Replace `pipe.base.timeMethod` with `utils.timer`

### DIFF
--- a/doc/lsst.pipe.base/creating-a-task.rst
+++ b/doc/lsst.pipe.base/creating-a-task.rst
@@ -208,7 +208,7 @@ This is safer than returning a tuple of items, and allows adding fields without 
 If your task's processing can be divided into logical units, then we recommend that you provide methods for each unit.
 ``run`` can then call each method to do its work.
 This allows your task to be more easily adapted: a subclass can override just a few methods.
-Any method that is likely to take significant time or memory should be preceded by this python decorator: `lsst.pipe.base.timeMethod`.
+Any method that is likely to take significant time or memory should be preceded by this python decorator: `lsst.utils.timer.timeMethod`.
 This automatically records the execution time and memory of the method in the task's ``metadata`` attribute.
 
 We strongly recommend that you make your task stateless, by not using instance variables as part of your data processing.
@@ -228,7 +228,7 @@ The example ``exampleCmdLineTask.ExampleCmdLineTask`` is so simple that it needs
 
 .. code-block:: python
 
-   @pipeBase.timeMethod
+   @lsst.utils.timer.timeMethod
    def runDataRef(self, dataRef):
        """Compute a few statistics on the image plane of an exposure
        @param dataRef: data reference for a calibrated science exposure ("calexp")
@@ -259,7 +259,7 @@ Here is the ``run`` method for the default version of that task: ``exampleTask.E
 
 .. code-block:: python
 
-   @pipeBase.timeMethod
+   @lsst.utils.timer.timeMethod
    def run(self, maskedImage):
        """!Compute and return statistics for a masked image
        @param[in] maskedImage: masked image (an lsst::afw::MaskedImage)

--- a/doc/lsst.pipe.base/task-framework-overview.rst
+++ b/doc/lsst.pipe.base/task-framework-overview.rst
@@ -45,6 +45,6 @@ Tasks that are associated with a particular package should be in that package; f
   command line.
 - `~lsst.pipe.base.Struct`: object returned by the run method of a task.
 - `~lsst.pipe.base.ArgumentParser`: command line parser for pipeline tasks.
-- `~lsst.pipe.base.timeMethod`: decorator to log performance information for a `~lsst.pipe.base.Task` method.
+- `~lsst.pipe.base.timeMethod`: decorator to log performance information for a `~lsst.pipe.base.Task` method (obsolete, replaced by `lsst.utils.timer.timeMethod`)
 - `~lsst.pipe.base.TaskRunner`: a class that runs command-line tasks using multiprocessing when requested.
   This will work as-is for most command-line tasks but will need to be be subclassed if, for instance, the task's run method needs something other than a single data reference.

--- a/python/lsst/pipe/base/timer.py
+++ b/python/lsst/pipe/base/timer.py
@@ -25,6 +25,7 @@ __all__ = ["logInfo", "timeMethod"]
 
 import logging
 from deprecated.sphinx import deprecated
+from typing import Any, Callable
 import lsst.utils.timer
 
 
@@ -73,5 +74,15 @@ def logInfo(obj, prefix, logLevel=logging.DEBUG, metadata=None, logger=None):
     return lsst.utils.timer.logInfo(obj, prefix, logLevel=logLevel, metadata=metadata, logger=logger)
 
 
-# Does this need a deprecation message?
-timeMethod = lsst.utils.timer.timeMethod
+@deprecated(reason="timeMethod has been replaced by lsst.utils.timer.timeMethod."
+            " Will be removed after v25.",
+            version="v24", category=FutureWarning)
+def timeMethod(*args: Any, **kwargs: Any) -> Callable:
+    """Decorator to measure duration of a method.
+
+    Notes
+    -----
+    This is a just a forwarding method for `lsst.utils.timer.timeMethod`. For
+    documentation look at `lsst.utils.timer.timeMethod`.
+    """
+    return lsst.utils.timer.timeMethod(*args, **kwargs)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -28,6 +28,7 @@ import lsst.utils.tests
 import lsst.daf.base as dafBase
 import lsst.pex.config as pexConfig
 import lsst.pipe.base as pipeBase
+from lsst.utils.timer import timeMethod
 
 
 class AddConfig(pexConfig.Config):
@@ -37,7 +38,7 @@ class AddConfig(pexConfig.Config):
 class AddTask(pipeBase.Task):
     ConfigClass = AddConfig
 
-    @pipeBase.timeMethod
+    @timeMethod
     def run(self, val):
         self.metadata.add("add", self.config.addend)
         return pipeBase.Struct(
@@ -52,7 +53,7 @@ class MultConfig(pexConfig.Config):
 class MultTask(pipeBase.Task):
     ConfigClass = MultConfig
 
-    @pipeBase.timeMethod
+    @timeMethod
     def run(self, val):
         self.metadata.add("mult", self.config.multiplicand)
         return pipeBase.Struct(
@@ -82,7 +83,7 @@ class AddMultTask(pipeBase.Task):
         self.makeSubtask("add")
         self.makeSubtask("mult")
 
-    @pipeBase.timeMethod
+    @timeMethod
     def run(self, val):
         with self.timer("context"):
             addRet = self.add.run(val)
@@ -92,7 +93,7 @@ class AddMultTask(pipeBase.Task):
                 val=multRet.val,
             )
 
-    @pipeBase.timeMethod
+    @timeMethod
     def failDec(self):
         """A method that fails with a decorator
         """


### PR DESCRIPTION
`timeMethod` in this package is re-implemented as a trivia wrapper for
`pipe.base.timeMethod`, and declared deprecated.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
