### PR TITLE
DM-31723: Switch one file from ButlerURI to ResourcePath

### DIFF
--- a/ups/pipe_base.table
+++ b/ups/pipe_base.table
@@ -4,5 +4,6 @@ setupRequired(log)
 setupRequired(pex_config)
 setupRequired(utils)
 setupRequired(afw)
+setupRequired(resources)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
It was using internal implementation classes so could not use
the backwards compatibility export from daf_butler.

Requires lsst/resources#1

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
