### PR TITLE
DM-33204: Use ResourcePath instead of ButlerURI throughout.

### DIFF
--- a/doc/lsst.pipe.base/creating-a-pipeline.rst
+++ b/doc/lsst.pipe.base/creating-a-pipeline.rst
@@ -27,7 +27,7 @@ s, and discussing common conventions when creating `Pipelines`.
 A Basic Pipeline
 ----------------
 
-`Pipeline` documents are written using yaml syntax. If you are unfamiliar with 
+`Pipeline` documents are written using yaml syntax. If you are unfamiliar with
 yaml, there are many guides across the internet, but the basic idea is that it
 is a simple markup language to describe key, value mappings, and lists of
 values (which may be further mappings).
@@ -109,12 +109,12 @@ configuration options that alter the way the task executes. Because
 description field) some tasks may need specific configurations set to
 enable/disable behavior in the context of the specific `Pipeline`.
 
-To configure a task associated with a particular label, the value associated 
+To configure a task associated with a particular label, the value associated
 with the label must be changed from the qualified task name to a new
 sub-mapping. This new sub mapping should have two keys, ``class`` and
 ``config``.
 
-The ``class`` key should point to the same qualified task name as before. The 
+The ``class`` key should point to the same qualified task name as before. The
 value associated with the ``config`` keyword is itself a mapping where
 configuration overrides are declared. The example below shows this behavior
 in action.
@@ -371,7 +371,7 @@ extend the total `Pipeline`.
 
 If a ``label`` declared in the the ``tasks`` section was declared in one of
 the imported ``Pipelines``, one of two things happen. If the label is
-associated with the same `PipelineTask` that was declared in the imported 
+associated with the same `PipelineTask` that was declared in the imported
 pipeline, this definition will be extended. This means that any configs
 declared in the imported `Pipeline` will be merged with configs declared in
 the current `Pipeline` with the current declaration taking config precedence.
@@ -421,7 +421,7 @@ is loaded.
 
 The simplest form of a `Pipeline` specification is the URI at which the
 `Pipeline` can be found. This URI may be any supported by
-`lsst.daf.butler.ButlerURI`. In the case that the pipeline resides in a file
+`lsst.resources.ResourcePath`. In the case that the pipeline resides in a file
 located on a filesystem accessible by the machine that will be processing the
 `Pipeline` (i.e. a file URI), there is no need to preface the URI with
 ``file://``, a bare file path is assumed to be a file based URI.

--- a/python/lsst/pipe/base/executionButlerBuilder.py
+++ b/python/lsst/pipe/base/executionButlerBuilder.py
@@ -27,9 +27,10 @@ import itertools
 from collections import defaultdict
 from typing import Callable, DefaultDict, Iterable, List, Mapping, Optional, Set, Tuple, Union
 
-from lsst.daf.butler import Butler, ButlerURI, Config, DataCoordinate, DatasetRef, DatasetType
+from lsst.daf.butler import Butler, Config, DataCoordinate, DatasetRef, DatasetType
 from lsst.daf.butler.core.repoRelocation import BUTLER_ROOT_TAG
 from lsst.daf.butler.transfers import RepoExportContext
+from lsst.resources import ResourcePath, ResourcePathExpression
 from lsst.utils.introspection import get_class_of
 
 from .graph import QuantumGraph, QuantumNode
@@ -142,7 +143,7 @@ def _export(
     return yamlBuffer
 
 
-def _setupNewButler(butler: Butler, outputLocation: ButlerURI, dirExists: bool) -> Butler:
+def _setupNewButler(butler: Butler, outputLocation: ResourcePath, dirExists: bool) -> Butler:
     # Set up the new butler object at the specified location
     if dirExists:
         # Remove the existing table, if the code got this far and this exists
@@ -218,7 +219,7 @@ def _import(
 def buildExecutionButler(
     butler: Butler,
     graph: QuantumGraph,
-    outputLocation: Union[str, ButlerURI],
+    outputLocation: ResourcePathExpression,
     run: str,
     *,
     clobber: bool = False,
@@ -242,9 +243,9 @@ def buildExecutionButler(
     graph : `QuantumGraph`
         Graph containing nodes that are to be exported into an execution
         butler
-    outputLocation : `str` or `~lsst.daf.butler.ButlerURI`
+    outputLocation : convertible to `ResourcePath
         URI Location at which the execution butler is to be exported. May be
-        specified as a string or a ButlerURI instance.
+        specified as a string or a `ResourcePath` instance.
     run : `str` optional
         The run collection that the exported datasets are to be placed in. If
         None, the default value in registry.defaults will be used.
@@ -282,7 +283,7 @@ def buildExecutionButler(
         Raised if specified output URI does not correspond to a directory
     """
     # We know this must refer to a directory.
-    outputLocation = ButlerURI(outputLocation, forceDirectory=True)
+    outputLocation = ResourcePath(outputLocation, forceDirectory=True)
 
     # Do this first to Fail Fast if the output exists
     if (dirExists := outputLocation.exists()) and not clobber:

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -33,7 +33,7 @@ from typing import Any, Dict, Generator, List, Mapping, MutableMapping, Optional
 
 import yaml
 from deprecated.sphinx import deprecated
-from lsst.daf.butler import ButlerURI
+from lsst.resources import ResourcePath, ResourcePathExpression
 
 
 class KeepInstrument:
@@ -859,13 +859,13 @@ class PipelineIR:
         return cls.from_uri(filename)
 
     @classmethod
-    def from_uri(cls, uri: Union[str, ButlerURI]) -> PipelineIR:
+    def from_uri(cls, uri: ResourcePathExpression) -> PipelineIR:
         """Create a `PipelineIR` object from the document specified by the
         input uri.
 
         Parameters
         ----------
-        uri: `str` or `ButlerURI`
+        uri: convertible to `ResourcePath`
             Location of document to use in creating a `PipelineIR` object.
 
         Returns
@@ -873,17 +873,12 @@ class PipelineIR:
         pipelineIR : `PipelineIR`
             The loaded pipeline
         """
-        loaded_uri = ButlerURI(uri)
-        # With ButlerURI we have the choice of always using a local file or
-        # reading in the bytes directly. Reading in bytes can be more
-        # efficient for reasonably-sized files when the resource is remote.
-        # For now use the local file variant. For a local file as_local() does
-        # nothing.
-        with loaded_uri.as_local() as local:
+        loaded_uri = ResourcePath(uri)
+        with loaded_uri.open("r") as buffer:
             # explicitly read here, there was some issue with yaml trying
-            # to read the ButlerURI itself (I think because it only
+            # to read the ResourcePath itself (I think because it only
             # pretends to be conformant to the io api)
-            loaded_yaml = yaml.load(local.read(), Loader=PipelineYamlLoader)
+            loaded_yaml = yaml.load(buffer.read(), Loader=PipelineYamlLoader)
             return cls(loaded_yaml)
 
     @deprecated(
@@ -902,17 +897,20 @@ class PipelineIR:
         """
         self.write_to_uri(filename)
 
-    def write_to_uri(self, uri: Union[ButlerURI, str]):
+    def write_to_uri(
+        self,
+        uri: ResourcePathExpression,
+    ):
         """Serialize this `PipelineIR` object into a yaml formatted string and
         write the output to a file at the specified uri.
 
         Parameters
         ----------
-        uri: `str` or `ButlerURI`
+        uri: convertible to `ResourcePath`
             Location of document to write a `PipelineIR` object.
         """
-        butlerUri = ButlerURI(uri)
-        butlerUri.write(yaml.dump(self.to_primitives(), sort_keys=False).encode())
+        with ResourcePath(uri).open("w") as buffer:
+            yaml.dump(self.to_primitives(), buffer, sort_keys=False)
 
     def to_primitives(self) -> Dict[str, Any]:
         """Convert to a representation used in yaml serialization"""

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -31,8 +31,9 @@ import lsst.daf.butler.tests as butlerTests
 import lsst.pex.config as pexConfig
 import numpy
 from lsst.base import Packages
-from lsst.daf.butler import Butler, ButlerURI, Config, DatasetType
+from lsst.daf.butler import Butler, Config, DatasetType
 from lsst.daf.butler.core.logging import ButlerLogRecords
+from lsst.resources import ResourcePath
 from lsst.utils import doImport
 
 from ... import base as pipeBase
@@ -236,7 +237,7 @@ def makeSimpleButler(root: str, run: str = "test", inMemory: bool = True) -> But
     butler : `~lsst.daf.butler.Butler`
         Data butler instance.
     """
-    root = ButlerURI(root, forceDirectory=True)
+    root = ResourcePath(root, forceDirectory=True)
     if not root.isLocal:
         raise ValueError(f"Only works with local root not {root}")
     config = Config()


### PR DESCRIPTION
Also replaces a few Union[str, ButlerURI] and similar with the new
ResourcePathExpression type alias.

This is essentially a cherry pick of commit b014171b from #222.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
