### PR TITLE
DM-33260 hotfix: make lsstimport optional

### DIFF
--- a/python/lsst/__init__.py
+++ b/python/lsst/__init__.py
@@ -1,5 +1,9 @@
 import pkgutil
 
-import lsstimport
+try:
+    import lsstimport
+except ImportError:
+    # Not generally needed.
+    pass
 
 __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
Hotfix for missed lsstimport in [DM-33260](https://jira.lsstcorp.org/browse/DM-33260).

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
