### PR TITLE
DM-3334: Use transfer_from to transfer datasets to execution butler

### DIFF
--- a/doc/changes/DM-33345.misc.rst
+++ b/doc/changes/DM-33345.misc.rst
@@ -1,0 +1,1 @@
+Execution butler creation time has been reduced significantly by avoiding unnecessary checks for existence of files in the datastore.


### PR DESCRIPTION
Transferring the datasets using export/import is slow
because each record has to be handled separately on re-ingest.
This requires file system checks.

Use transfer_from the datastore side is handled by bulk
queries of the file_datastore_records tables and the
files are assumed to exist and so are not checked.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
