### PR TITLE
DM-33853: Add verbose log message if get() is taking a long time

### DIFF
--- a/python/lsst/pipe/base/butlerQuantumContext.py
+++ b/python/lsst/pipe/base/butlerQuantumContext.py
@@ -29,6 +29,7 @@ __all__ = ("ButlerQuantumContext",)
 from typing import Any, List, Sequence, Union
 
 from lsst.daf.butler import Butler, DatasetRef, Quantum
+from lsst.utils.introspection import get_full_type_name
 
 from .connections import DeferredDatasetRef, InputQuantizedConnection, OutputQuantizedConnection
 from .struct import Struct
@@ -155,7 +156,9 @@ class ButlerQuantumContext:
         elif isinstance(dataset, DatasetRef) or isinstance(dataset, DeferredDatasetRef):
             return self._get(dataset)
         else:
-            raise TypeError("Dataset argument is not a type that can be used to get")
+            raise TypeError(
+                f"Dataset argument ({get_full_type_name(dataset)}) is not a type that can be used to get"
+            )
 
     def put(
         self,

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -246,6 +246,9 @@ class QuantizedConnection(SimpleNamespace):
         object.__delattr__(self, name)
         self._attributes.remove(name)
 
+    def __len__(self) -> int:
+        return len(self._attributes)
+
     def __iter__(
         self,
     ) -> typing.Generator[typing.Tuple[str, typing.Union[DatasetRef, typing.List[DatasetRef]]], None, None]:


### PR DESCRIPTION
On IDF some tasks take 7 hours in one call to `ButlerQuantumContext.get()`

Requires lsst/utils#116

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
