### PR TITLE
DM-34105: Move some generic code from obs_base

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
+        env:
+          DAF_BUTLER_PLUGINS: ${{ github.workspace }}/python/lsst/pipe/base/cli/resources.yaml
         run: |
           pytest -r a -v -n 3 --open-files --cov=lsst.pipe.base --cov=tests --cov-report=xml --cov-report=term --cov-branch
       - name: Upload coverage to codecov

--- a/doc/changes/DM-34105.feature.rst
+++ b/doc/changes/DM-34105.feature.rst
@@ -1,0 +1,3 @@
+* Added `lsst.pipe.base.Instrument` to represent an instrument in Butler registry.
+* Added ``butler register-instrument`` command.
+* Added a formatter for pex_config `Config` objects.

--- a/python/lsst/pipe/base/__init__.py
+++ b/python/lsst/pipe/base/__init__.py
@@ -1,4 +1,5 @@
 from . import connectionTypes, pipelineIR
+from ._instrument import *
 from ._status import *
 from ._task_metadata import *
 

--- a/python/lsst/pipe/base/_instrument.py
+++ b/python/lsst/pipe/base/_instrument.py
@@ -1,0 +1,412 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("Instrument",)
+
+import datetime
+import os.path
+from abc import ABCMeta, abstractmethod
+from typing import TYPE_CHECKING, Optional, Sequence, Type, Union
+
+from lsst.daf.butler import DataId, Formatter
+from lsst.daf.butler.registry import DataIdError
+from lsst.utils import doImportType
+
+if TYPE_CHECKING:
+    from lsst.daf.butler import Registry
+    from lsst.pex.config import Config
+
+
+class Instrument(metaclass=ABCMeta):
+    """Base class for instrument-specific logic for the Gen3 Butler.
+
+    Parameters
+    ----------
+    collection_prefix : `str`, optional
+        Prefix for collection names to use instead of the intrument's own name.
+        This is primarily for use in simulated-data repositories, where the
+        instrument name may not be necessary and/or sufficient to distinguish
+        between collections.
+
+    Notes
+    -----
+    Concrete instrument subclasses must have the same construction signature as
+    the base class.
+    """
+
+    configPaths: Sequence[str] = ()
+    """Paths to config files to read for specific Tasks.
+
+    The paths in this list should contain files of the form `task.py`, for
+    each of the Tasks that requires special configuration.
+    """
+
+    policyName: Optional[str] = None
+    """Instrument specific name to use when locating a policy or configuration
+    file in the file system."""
+
+    def __init__(self, collection_prefix: Optional[str] = None):
+        if collection_prefix is None:
+            collection_prefix = self.getName()
+        self.collection_prefix = collection_prefix
+
+    @classmethod
+    @abstractmethod
+    def getName(cls) -> str:
+        """Return the short (dimension) name for this instrument.
+
+        This is not (in general) the same as the class name - it's what is used
+        as the value of the "instrument" field in data IDs, and is usually an
+        abbreviation of the full name.
+        """
+        raise NotImplementedError()
+
+    @abstractmethod
+    def register(self, registry: Registry, *, update: bool = False) -> None:
+        """Insert instrument, and other relevant records into `Registry`.
+
+        Parameters
+        ----------
+        registry : `lsst.daf.butler.Registry`
+            Registry client for the data repository to modify.
+        update : `bool`, optional
+            If `True` (`False` is default), update existing records if they
+            differ from the new ones.
+
+        Raises
+        ------
+        lsst.daf.butler.registry.ConflictingDefinitionError
+            Raised if any existing record has the same key but a different
+            definition as one being registered.
+
+        Notes
+        -----
+        New records can always be added by calling this method multiple times,
+        as long as no existing records have changed (if existing records have
+        changed, ``update=True`` must be used).  Old records can never be
+        removed by this method.
+
+        Implementations should guarantee that registration is atomic (the
+        registry should not be modified if any error occurs) and idempotent at
+        the level of individual dimension entries; new detectors and filters
+        should be added, but changes to any existing record should not be.
+        This can generally be achieved via a block like
+
+        .. code-block:: python
+
+            with registry.transaction():
+                registry.syncDimensionData("instrument", ...)
+                registry.syncDimensionData("detector", ...)
+                self.registerFilters(registry)
+
+        """
+        raise NotImplementedError()
+
+    @staticmethod
+    def fromName(name: str, registry: Registry, collection_prefix: Optional[str] = None) -> Instrument:
+        """Given an instrument name and a butler registry, retrieve a
+        corresponding instantiated instrument object.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the instrument (must match the return value of `getName`).
+        registry : `lsst.daf.butler.Registry`
+            Butler registry to query to find the information.
+        collection_prefix : `str`, optional
+            Prefix for collection names to use instead of the intrument's own
+            name.  This is primarily for use in simulated-data repositories,
+            where the instrument name may not be necessary and/or sufficient to
+            distinguish between collections.
+
+        Returns
+        -------
+        instrument : `Instrument`
+            An instance of the relevant `Instrument`.
+
+        Notes
+        -----
+        The instrument must be registered in the corresponding butler.
+
+        Raises
+        ------
+        LookupError
+            Raised if the instrument is not known to the supplied registry.
+        ModuleNotFoundError
+            Raised if the class could not be imported.  This could mean
+            that the relevant obs package has not been setup.
+        TypeError
+            Raised if the class name retrieved is not a string or the imported
+            symbol is not an `Instrument` subclass.
+        """
+        try:
+            records = list(registry.queryDimensionRecords("instrument", instrument=name))
+        except DataIdError:
+            records = None
+        if not records:
+            raise LookupError(f"No registered instrument with name '{name}'.")
+        cls_name = records[0].class_name
+        if not isinstance(cls_name, str):
+            raise TypeError(
+                f"Unexpected class name retrieved from {name} instrument dimension (got {cls_name})"
+            )
+        instrument_cls: type = doImportType(cls_name)
+        if not issubclass(instrument_cls, Instrument):
+            raise TypeError(
+                f"{instrument_cls!r}, obtained from importing {cls_name}, is not an Instrument subclass."
+            )
+        return instrument_cls(collection_prefix=collection_prefix)
+
+    @staticmethod
+    def importAll(registry: Registry) -> None:
+        """Import all the instruments known to this registry.
+
+        This will ensure that all metadata translators have been registered.
+
+        Parameters
+        ----------
+        registry : `lsst.daf.butler.Registry`
+            Butler registry to query to find the information.
+
+        Notes
+        -----
+        It is allowed for a particular instrument class to fail on import.
+        This might simply indicate that a particular obs package has
+        not been setup.
+        """
+        records = list(registry.queryDimensionRecords("instrument"))
+        for record in records:
+            cls = record.class_name
+            try:
+                doImportType(cls)
+            except Exception:
+                pass
+
+    @abstractmethod
+    def getRawFormatter(self, dataId: DataId) -> Type[Formatter]:
+        """Return the Formatter class that should be used to read a particular
+        raw file.
+
+        Parameters
+        ----------
+        dataId : `DataId`
+            Dimension-based ID for the raw file or files being ingested.
+
+        Returns
+        -------
+        formatter : `lsst.daf.butler.Formatter` class
+            Class to be used that reads the file into the correct
+            Python object for the raw data.
+        """
+        raise NotImplementedError()
+
+    def applyConfigOverrides(self, name: str, config: Config) -> None:
+        """Apply instrument-specific overrides for a task config.
+
+        Parameters
+        ----------
+        name : `str`
+            Name of the object being configured; typically the _DefaultName
+            of a Task.
+        config : `lsst.pex.config.Config`
+            Config instance to which overrides should be applied.
+        """
+        for root in self.configPaths:
+            path = os.path.join(root, f"{name}.py")
+            if os.path.exists(path):
+                config.load(path)
+
+    @staticmethod
+    def formatCollectionTimestamp(timestamp: Union[str, datetime.datetime]) -> str:
+        """Format a timestamp for use in a collection name.
+
+        Parameters
+        ----------
+        timestamp : `str` or `datetime.datetime`
+            Timestamp to format.  May be a date or datetime string in extended
+            ISO format (assumed UTC), with or without a timezone specifier, a
+            datetime string in basic ISO format with a timezone specifier, a
+            naive `datetime.datetime` instance (assumed UTC) or a
+            timezone-aware `datetime.datetime` instance (converted to UTC).
+            This is intended to cover all forms that string ``CALIBDATE``
+            metadata values have taken in the past, as well as the format this
+            method itself writes out (to enable round-tripping).
+
+        Returns
+        -------
+        formatted : `str`
+            Standardized string form for the timestamp.
+        """
+        if isinstance(timestamp, str):
+            if "-" in timestamp:
+                # extended ISO format, with - and : delimiters
+                timestamp = datetime.datetime.fromisoformat(timestamp)
+            else:
+                # basic ISO format, with no delimiters (what this method
+                # returns)
+                timestamp = datetime.datetime.strptime(timestamp, "%Y%m%dT%H%M%S%z")
+        if not isinstance(timestamp, datetime.datetime):
+            raise TypeError(f"Unexpected date/time object: {timestamp!r}.")
+        if timestamp.tzinfo is not None:
+            timestamp = timestamp.astimezone(datetime.timezone.utc)
+        return f"{timestamp:%Y%m%dT%H%M%S}Z"
+
+    @staticmethod
+    def makeCollectionTimestamp() -> str:
+        """Create a timestamp string for use in a collection name from the
+        current time.
+
+        Returns
+        -------
+        formatted : `str`
+            Standardized string form of the current time.
+        """
+        return Instrument.formatCollectionTimestamp(datetime.datetime.now(tz=datetime.timezone.utc))
+
+    def makeDefaultRawIngestRunName(self) -> str:
+        """Make the default instrument-specific run collection string for raw
+        data ingest.
+
+        Returns
+        -------
+        coll : `str`
+            Run collection name to be used as the default for ingestion of
+            raws.
+        """
+        return self.makeCollectionName("raw", "all")
+
+    def makeUnboundedCalibrationRunName(self, *labels: str) -> str:
+        """Make a RUN collection name appropriate for inserting calibration
+        datasets whose validity ranges are unbounded.
+
+        Parameters
+        ----------
+        *labels : `str`
+            Extra strings to be included in the base name, using the default
+            delimiter for collection names.  Usually this is the name of the
+            ticket on which the calibration collection is being created.
+
+        Returns
+        -------
+        name : `str`
+            Run collection name.
+        """
+        return self.makeCollectionName("calib", *labels, "unbounded")
+
+    def makeCuratedCalibrationRunName(self, calibDate: str, *labels: str) -> str:
+        """Make a RUN collection name appropriate for inserting curated
+        calibration datasets with the given ``CALIBDATE`` metadata value.
+
+        Parameters
+        ----------
+        calibDate : `str`
+            The ``CALIBDATE`` metadata value.
+        *labels : `str`
+            Strings to be included in the collection name (before
+            ``calibDate``, but after all other terms), using the default
+            delimiter for collection names.  Usually this is the name of the
+            ticket on which the calibration collection is being created.
+
+        Returns
+        -------
+        name : `str`
+            Run collection name.
+        """
+        return self.makeCollectionName("calib", *labels, "curated", self.formatCollectionTimestamp(calibDate))
+
+    def makeCalibrationCollectionName(self, *labels: str) -> str:
+        """Make a CALIBRATION collection name appropriate for associating
+        calibration datasets with validity ranges.
+
+        Parameters
+        ----------
+        *labels : `str`
+            Strings to be appended to the base name, using the default
+            delimiter for collection names.  Usually this is the name of the
+            ticket on which the calibration collection is being created.
+
+        Returns
+        -------
+        name : `str`
+            Calibration collection name.
+        """
+        return self.makeCollectionName("calib", *labels)
+
+    @staticmethod
+    def makeRefCatCollectionName(*labels: str) -> str:
+        """Return a global (not instrument-specific) name for a collection that
+        holds reference catalogs.
+
+        With no arguments, this returns the name of the collection that holds
+        all reference catalogs (usually a ``CHAINED`` collection, at least in
+        long-lived repos that may contain more than one reference catalog).
+
+        Parameters
+        ----------
+        *labels : `str`
+            Strings to be added to the global collection name, in order to
+            define a collection name for one or more reference catalogs being
+            ingested at the same time.
+
+        Returns
+        -------
+        name : `str`
+            Collection name.
+
+        Notes
+        -----
+        This is a ``staticmethod``, not a ``classmethod``, because it should
+        be the same for all instruments.
+        """
+        return "/".join(("refcats",) + labels)
+
+    def makeUmbrellaCollectionName(self) -> str:
+        """Return the name of the umbrella ``CHAINED`` collection for this
+        instrument that combines all standard recommended input collections.
+
+        This method should almost never be overridden by derived classes.
+
+        Returns
+        -------
+        name : `str`
+            Name for the umbrella collection.
+        """
+        return self.makeCollectionName("defaults")
+
+    def makeCollectionName(self, *labels: str) -> str:
+        """Get the instrument-specific collection string to use as derived
+        from the supplied labels.
+
+        Parameters
+        ----------
+        *labels : `str`
+            Strings to be combined with the instrument name to form a
+            collection name.
+
+        Returns
+        -------
+        name : `str`
+            Collection name to use that includes the instrument's recommended
+            prefix.
+        """
+        return "/".join((self.collection_prefix,) + labels)

--- a/python/lsst/pipe/base/cli/cmd/__init__.py
+++ b/python/lsst/pipe/base/cli/cmd/__init__.py
@@ -1,0 +1,24 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["register_instrument"]
+
+from .commands import register_instrument

--- a/python/lsst/pipe/base/cli/cmd/commands.py
+++ b/python/lsst/pipe/base/cli/cmd/commands.py
@@ -1,0 +1,38 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any
+
+import click
+from lsst.daf.butler.cli.opt import repo_argument
+from lsst.daf.butler.cli.utils import ButlerCommand
+
+from ... import script
+from ..opt import instrument_argument
+
+
+@click.command(short_help="Add an instrument definition to the repository", cls=ButlerCommand)
+@repo_argument(required=True)
+@instrument_argument(required=True, nargs=-1, help="The fully-qualified name of an Instrument subclass.")
+@click.option("--update", is_flag=True)
+def register_instrument(*args: Any, **kwargs: Any) -> None:
+    """Add an instrument to the data repository."""
+    script.register_instrument(*args, **kwargs)

--- a/python/lsst/pipe/base/cli/opt/__init__.py
+++ b/python/lsst/pipe/base/cli/opt/__init__.py
@@ -1,0 +1,23 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .arguments import *
+from .options import *

--- a/python/lsst/pipe/base/cli/opt/arguments.py
+++ b/python/lsst/pipe/base/cli/opt/arguments.py
@@ -1,0 +1,26 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lsst.daf.butler.cli.utils import MWArgumentDecorator
+
+instrument_argument = MWArgumentDecorator(
+    "instrument", help="The name or fully-qualified class name of an instrument."
+)

--- a/python/lsst/pipe/base/cli/opt/options.py
+++ b/python/lsst/pipe/base/cli/opt/options.py
@@ -1,0 +1,26 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lsst.daf.butler.cli.utils import MWOptionDecorator
+
+instrument_option = MWOptionDecorator(
+    "--instrument", help="The name or fully-qualified class name of an instrument."
+)

--- a/python/lsst/pipe/base/cli/resources.yaml
+++ b/python/lsst/pipe/base/cli/resources.yaml
@@ -1,0 +1,4 @@
+cmd:
+  import: lsst.pipe.base.cli.cmd
+  commands:
+    - register-instrument

--- a/python/lsst/pipe/base/formatters/pexConfig.py
+++ b/python/lsst/pipe/base/formatters/pexConfig.py
@@ -1,0 +1,76 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+__all__ = ("PexConfigFormatter",)
+
+import os.path
+from typing import Any, Optional, Type
+
+from lsst.daf.butler.formatters.file import FileFormatter
+from lsst.pex.config import Config
+
+
+class PexConfigFormatter(FileFormatter):
+    """Formatter implementation for reading and writing
+    `lsst.pex.config.Config` instances."""
+
+    extension = ".py"
+
+    def _readFile(self, path: str, pytype: Optional[Type[Any]] = None) -> Any:
+        """Read a pex.config.Config instance from the given file.
+
+        Parameters
+        ----------
+        path : `str`
+            Path to use to open the file.
+        pytype : `type`, optional
+            Class to use to read the config file.
+
+        Returns
+        -------
+        data : `lsst.pex.config.Config`
+            Instance of class ``pytype`` read from config file. `None`
+            if the file could not be opened.
+        """
+        if not os.path.exists(path):
+            return None
+
+        # Automatically determine the Config class from the serialized form
+        with open(path, "r") as fd:
+            config_py = fd.read()
+        return Config._fromPython(config_py)
+
+    def _writeFile(self, inMemoryDataset: Any) -> None:
+        """Write the in memory dataset to file on disk.
+
+        Parameters
+        ----------
+        inMemoryDataset : `object`
+            Object to serialize.
+
+        Raises
+        ------
+        Exception
+            The file could not be written.
+        """
+        inMemoryDataset.save(self.fileDescriptor.location.path)

--- a/python/lsst/pipe/base/script/__init__.py
+++ b/python/lsst/pipe/base/script/__init__.py
@@ -1,0 +1,22 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .register_instrument import register_instrument

--- a/python/lsst/pipe/base/script/register_instrument.py
+++ b/python/lsst/pipe/base/script/register_instrument.py
@@ -1,0 +1,55 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ["register_instrument"]
+
+from typing import List
+
+from lsst.daf.butler import Butler
+from lsst.pipe.base import Instrument
+
+
+def register_instrument(repo: str, instrument: List[str], update: bool = False) -> None:
+    """Add an instrument to the data repository.
+
+    Parameters
+    ----------
+    repo : `str`
+        URI to the butler repository to register this instrument.
+    instrument : `list` [`str`]
+        The fully-qualified name of an `~lsst.pipe.base.Instrument` subclass.
+    update : `bool`, optional
+        If `True` (`False` is default), update the existing instrument and
+        detector records if they differ from the new ones.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if the instrument can not be imported, instantiated, or obtained
+        from the registry.
+    TypeError
+        Raised iff the instrument is not a subclass of
+        `lsst.pipe.base.Instrument`.
+    """
+    butler = Butler(repo, writeable=True)
+    for string in instrument:
+        instrument_instance = Instrument.from_string(string, butler.registry)
+        instrument_instance.register(butler.registry, update=update)

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -37,12 +37,13 @@ try:
     from lsst.base import Packages
 except ImportError:
     Packages = None
-from lsst.daf.butler import Butler, Config, DatasetType
+from lsst.daf.butler import Butler, Config, DataId, DatasetType, Formatter
 from lsst.daf.butler.core.logging import ButlerLogRecords
 from lsst.resources import ResourcePath
 from lsst.utils import doImportType
 
 from .. import connectionTypes as cT
+from .._instrument import Instrument
 from ..config import PipelineTaskConfig
 from ..connections import PipelineTaskConnections
 from ..graph import QuantumGraph
@@ -62,10 +63,7 @@ if TYPE_CHECKING:
 _LOG = logging.getLogger(__name__)
 
 
-# SimpleInstrument has an instrument-like API as needed for unit testing, but
-# can not explicitly depend on Instrument because pipe_base does not explicitly
-# depend on obs_base.
-class SimpleInstrument:
+class SimpleInstrument(Instrument):
     def __init__(self, *args: Any, **kwargs: Any):
         pass
 
@@ -73,7 +71,10 @@ class SimpleInstrument:
     def getName() -> str:
         return "INSTRU"
 
-    def applyConfigOverrides(self, name: str, config: pexConfig.Config) -> None:
+    def getRawFormatter(self, dataId: DataId) -> Type[Formatter]:
+        return Formatter
+
+    def register(self, registry: Registry, *, update: bool = False) -> None:
         pass
 
 

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -32,11 +32,6 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Ty
 import lsst.daf.butler.tests as butlerTests
 import lsst.pex.config as pexConfig
 import numpy
-
-try:
-    from lsst.base import Packages
-except ImportError:
-    Packages = None
 from lsst.daf.butler import Butler, Config, DataId, DatasetType, Formatter
 from lsst.daf.butler.core.logging import ButlerLogRecords
 from lsst.resources import ResourcePath
@@ -192,7 +187,7 @@ def registerDatasetTypes(registry: Registry, pipeline: Union[Pipeline, Iterable[
         configDatasetType = DatasetType(
             taskDef.configDatasetName, {}, storageClass="Config", universe=registry.dimensions
         )
-        storageClass = "Packages" if Packages is not None else "StructuredDataDict"
+        storageClass = "Packages"
         packagesDatasetType = DatasetType(
             "packages", {}, storageClass=storageClass, universe=registry.dimensions
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,10 +45,10 @@ lsst.pipe.base = py.typed
 [flake8]
 max-line-length = 110
 max-doc-length = 79
-ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503, E203
+ignore = E203, W503, N802, N803, N806, N812, N815, N816, W503,
 exclude = __init__.py
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503 E203
+flake8-ignore = E203 W503 N802 N803 N806 N812 N815 N816
   tests/data/*

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,4 +1,9 @@
 # -*- python -*-
-from lsst.sconsUtils import scripts
+import os
+
+from lsst.sconsUtils import env, scripts
 
 scripts.BasicSConscript.tests(pyList=[])
+
+if "DAF_BUTLER_PLUGINS" in os.environ:
+    env["ENV"]["DAF_BUTLER_PLUGINS"] = os.environ["DAF_BUTLER_PLUGINS"]

--- a/tests/test_cliCmdRegisterInstrument.py
+++ b/tests/test_cliCmdRegisterInstrument.py
@@ -1,0 +1,57 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for daf_butler CLI register-instrument command.
+"""
+
+import unittest
+
+from lsst.daf.butler.tests import CliCmdTestBase
+from lsst.pipe.base.cli.cmd import register_instrument
+
+
+class RegisterInstrumentTest(CliCmdTestBase, unittest.TestCase):
+
+    mockFuncName = "lsst.pipe.base.cli.cmd.commands.script.register_instrument"
+
+    @staticmethod
+    def defaultExpected():
+        return dict()
+
+    @staticmethod
+    def command():
+        return register_instrument
+
+    def test_repoBasic(self):
+        """Test the most basic required arguments."""
+        self.run_test(
+            ["register-instrument", "here", "a.b.c"],
+            self.makeExpected(repo="here", instrument=("a.b.c",), update=False),
+        )
+
+    def test_missing(self):
+        """test a missing argument"""
+        self.run_missing(["register-instrument"], "Missing argument ['\"]REPO['\"]")
+        self.run_missing(["register-instrument", "here"], "Missing argument ['\"]INSTRUMENT ...['\"]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config_formatter.py
+++ b/tests/test_config_formatter.py
@@ -1,0 +1,71 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for PexConfigFormatter.
+"""
+
+import os
+import unittest
+
+import lsst.pex.config
+from lsst.daf.butler import Butler, DatasetType
+from lsst.daf.butler.tests.utils import makeTestTempDir, removeTestTempDir
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class SimpleConfig(lsst.pex.config.Config):
+    """Config to use in tests for butler put/get"""
+
+    i = lsst.pex.config.Field("integer test", int)
+    c = lsst.pex.config.Field("string", str)
+
+
+class PexConfigFormatterTestCase(unittest.TestCase):
+    """Tests for PexConfigFormatter, using local file datastore."""
+
+    def setUp(self):
+        """Create a new butler root for each test."""
+        self.root = makeTestTempDir(TESTDIR)
+        Butler.makeRepo(self.root)
+        self.butler = Butler(self.root, run="test_run")
+        # No dimensions in dataset type so we don't have to worry about
+        # inserting dimension data or defining data IDs.
+        self.datasetType = DatasetType(
+            "config", dimensions=(), storageClass="Config", universe=self.butler.registry.dimensions
+        )
+        self.butler.registry.registerDatasetType(self.datasetType)
+
+    def tearDown(self):
+        removeTestTempDir(self.root)
+
+    def testPexConfig(self) -> None:
+        """Test that we can put and get pex_config Configs"""
+        c = SimpleConfig(i=10, c="hello")
+        self.assertEqual(c.i, 10)
+        ref = self.butler.put(c, "config")
+        butler_c = self.butler.get(ref)
+        self.assertEqual(c, butler_c)
+        self.assertIsInstance(butler_c, SimpleConfig)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,178 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests of the Instrument class.
+"""
+
+import datetime
+import unittest
+
+from lsst.daf.butler import Registry, RegistryConfig
+from lsst.daf.butler.formatters.json import JsonFormatter
+from lsst.pipe.base import Instrument
+from lsst.utils.introspection import get_full_type_name
+
+
+class DummyInstrument(Instrument):
+    @classmethod
+    def getName(cls):
+        return "DummyInstrument"
+
+    def register(self, registry, update=False):
+        detector_max = 2
+        record = {
+            "instrument": self.getName(),
+            "class_name": get_full_type_name(DummyInstrument),
+            "detector_max": detector_max,
+        }
+        with registry.transaction():
+            registry.syncDimensionData("instrument", record, update=update)
+
+    def getRawFormatter(self, dataId):
+        return JsonFormatter
+
+
+class BadInstrument(DummyInstrument):
+    """Instrument with wrong class name."""
+
+    @classmethod
+    def getName(cls):
+        return "BadInstrument"
+
+    def register(self, registry, update=False):
+        # Register a bad class name
+        record = {
+            "instrument": self.getName(),
+            "class_name": "builtins.str",
+            "detector_max": 1,
+        }
+        registry.syncDimensionData("instrument", record, update=update)
+
+
+class UnimportableInstrument(DummyInstrument):
+    """Instrument with class name that does not exist."""
+
+    @classmethod
+    def getName(cls):
+        return "NoImportInstr"
+
+    def register(self, registry, update=False):
+        # Register a bad class name
+        record = {
+            "instrument": self.getName(),
+            "class_name": "not.importable",
+            "detector_max": 1,
+        }
+        registry.syncDimensionData("instrument", record, update=update)
+
+
+class InstrumentTestCase(unittest.TestCase):
+    """Test for Instrument."""
+
+    def setUp(self):
+        self.instrument = DummyInstrument()
+        self.name = "DummyInstrument"
+
+    def test_basics(self):
+        self.assertEqual(self.instrument.getName(), self.name)
+        self.assertEqual(self.instrument.getRawFormatter({}), JsonFormatter)
+
+    def test_register(self):
+        """Test that register() sets appropriate Dimensions."""
+        registryConfig = RegistryConfig()
+        registryConfig["db"] = "sqlite://"
+        registry = Registry.createFromConfig(registryConfig)
+        # Check that the registry starts out empty.
+        self.instrument.importAll(registry)
+        self.assertFalse(list(registry.queryDimensionRecords("instrument")))
+
+        # Register and check again.
+        self.instrument.register(registry)
+        instruments = list(registry.queryDimensionRecords("instrument"))
+        self.assertEqual(len(instruments), 1)
+        self.assertEqual(instruments[0].name, self.name)
+        self.assertEqual(instruments[0].detector_max, 2)
+        self.assertIn("DummyInstrument", instruments[0].class_name)
+
+        self.instrument.importAll(registry)
+        from_registry = DummyInstrument.fromName("DummyInstrument", registry)
+        self.assertIsInstance(from_registry, Instrument)
+        with self.assertRaises(LookupError):
+            Instrument.fromName("NotThrere", registry)
+
+        # Register a bad instrument.
+        BadInstrument().register(registry)
+        with self.assertRaises(TypeError):
+            Instrument.fromName("BadInstrument", registry)
+
+        UnimportableInstrument().register(registry)
+        with self.assertRaises(ImportError):
+            Instrument.fromName("NoImportInstr", registry)
+
+        # This should work even with the bad class name.
+        self.instrument.importAll(registry)
+
+    def test_defaults(self):
+        self.assertEqual(self.instrument.makeDefaultRawIngestRunName(), "DummyInstrument/raw/all")
+        self.assertEqual(
+            self.instrument.makeUnboundedCalibrationRunName("a", "b"), "DummyInstrument/calib/a/b/unbounded"
+        )
+        self.assertEqual(
+            self.instrument.makeCuratedCalibrationRunName("2018-05-04", "a"),
+            "DummyInstrument/calib/a/curated/20180504T000000Z",
+        )
+        self.assertEqual(self.instrument.makeCalibrationCollectionName("c"), "DummyInstrument/calib/c")
+        self.assertEqual(self.instrument.makeRefCatCollectionName(), "refcats")
+        self.assertEqual(self.instrument.makeRefCatCollectionName("a"), "refcats/a")
+        self.assertEqual(self.instrument.makeUmbrellaCollectionName(), "DummyInstrument/defaults")
+
+        instrument = DummyInstrument(collection_prefix="Different")
+        self.assertEqual(instrument.makeCollectionName("a"), "Different/a")
+        self.assertEqual(self.instrument.makeCollectionName("a"), "DummyInstrument/a")
+
+    def test_collection_timestamps(self):
+        self.assertEqual(
+            Instrument.formatCollectionTimestamp("2018-05-03"),
+            "20180503T000000Z",
+        )
+        self.assertEqual(
+            Instrument.formatCollectionTimestamp("2018-05-03T14:32:16"),
+            "20180503T143216Z",
+        )
+        self.assertEqual(
+            Instrument.formatCollectionTimestamp("20180503T143216Z"),
+            "20180503T143216Z",
+        )
+        self.assertEqual(
+            Instrument.formatCollectionTimestamp(datetime.datetime(2018, 5, 3, 14, 32, 16)),
+            "20180503T143216Z",
+        )
+        formattedNow = Instrument.makeCollectionTimestamp()
+        self.assertIsInstance(formattedNow, str)
+        datetimeThen1 = datetime.datetime.strptime(formattedNow, "%Y%m%dT%H%M%S%z")
+        self.assertEqual(datetimeThen1.tzinfo, datetime.timezone.utc)
+
+        with self.assertRaises(TypeError):
+            Instrument.formatCollectionTimestamp(0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -161,14 +161,14 @@ class PipelineTaskTestCase(unittest.TestCase):
                 lsst.utils.logging.PeriodicLogger.LOGGING_INTERVAL = 0.0
 
                 checked_get = True
-                with self.assertLogs(level=lsst.utils.logging.VERBOSE) as cm:
+                with self.assertLogs("lsst.pipe.base", level=lsst.utils.logging.VERBOSE) as cm:
                     input_data = butlerQC.get(inputRefs)
                 self.assertIn("Completed", cm.output[-1])
                 self.assertEqual(len(input_data), len(inputRefs))
 
                 # In this test there are no multiples returned.
                 refs = [ref for _, ref in inputRefs]
-                with self.assertLogs(level=lsst.utils.logging.VERBOSE) as cm:
+                with self.assertLogs("lsst.pipe.base", level=lsst.utils.logging.VERBOSE) as cm:
                     list_get = butlerQC.get(refs)
 
                 lsst.utils.logging.PeriodicLogger.LOGGING_INTERVAL = 600.0

--- a/ups/pipe_base.table
+++ b/ups/pipe_base.table
@@ -8,3 +8,4 @@ setupRequired(resources)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)
 envPrepend(MYPYPATH, ${PRODUCT_DIR}/python)
+envPrepend(DAF_BUTLER_PLUGINS, ${PRODUCT_DIR}/python/lsst/pipe/base/cli/resources.yaml)


### PR DESCRIPTION
obs_base is going to be hard to disentangle from afw, ip_isr, and pipe_tasks. Move a subset of Instrument class to pipe_base along with support material.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
