### PR TITLE
DM-15325: Force Task to use kwargs for parameters other than config

### DIFF
--- a/doc/changes/DM-15325.misc.rst
+++ b/doc/changes/DM-15325.misc.rst
@@ -1,0 +1,2 @@
+Modified the calling signature for the ``Task`` constructor such that only the ``config`` parameter can be positional.
+All other parameters must now be keyword parameters.

--- a/python/lsst/pipe/base/task.py
+++ b/python/lsst/pipe/base/task.py
@@ -123,6 +123,9 @@ class Task:
 
     Notes
     -----
+    The constructor must use keyword parameters for everything other than
+    the ``config`` parameter which can be positional or use keyword form.
+
     Useful attributes include:
 
     - ``log``: an `logging.Logger` or subclass.
@@ -154,6 +157,7 @@ class Task:
     def __init__(
         self,
         config: Optional[Config] = None,
+        *,
         name: Optional[str] = None,
         parentTask: Optional[Task] = None,
         log: Optional[Union[logging.Logger, lsst.utils.logging.LsstLogAdapter]] = None,


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
