### PR TITLE
DM-34590: --longlog requires an unnecessary argument

### DIFF
--- a/doc/changes/DM-34590.bugfix.rst
+++ b/doc/changes/DM-34590.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed a bug where the Gen2 argument parser required an unused parameter for `--longlog`.

--- a/doc/changes/DM-34590.bugfix.rst
+++ b/doc/changes/DM-34590.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed a bug where the Gen2 argument parser required an unused parameter for `--longlog`.

--- a/python/lsst/pipe/base/argumentParser.py
+++ b/python/lsst/pipe/base/argumentParser.py
@@ -509,7 +509,12 @@ class ArgumentParser(argparse.ArgumentParser):
             help="logging level; supported levels are [trace|debug|info|warn|error|fatal]",
             metavar="LEVEL|COMPONENT=LEVEL",
         )
-        self.add_argument("--longlog", action=LongLogAction, help="use a more verbose format for the logging")
+        self.add_argument(
+            "--longlog",
+            nargs=0,
+            action=LongLogAction,
+            help="use a more verbose format for the logging",
+        )
         self.add_argument("--debug", action="store_true", help="enable debugging output?")
         self.add_argument(
             "--doraise",


### PR DESCRIPTION
--longlog is supposed to be a switch, and not require an argument,
but it was requiring one due to the absence of nargs=0.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
