### PR TITLE
DM-33942: Use a negative integer for test universe

### DIFF
--- a/tests/test_quantumGraph.py
+++ b/tests/test_quantumGraph.py
@@ -123,6 +123,7 @@ class QuantumGraphTestCase(unittest.TestCase):
         config = Config(
             {
                 "version": 1,
+                "namespace": "pipe_base_test",
                 "skypix": {
                     "common": "htm7",
                     "htm": {


### PR DESCRIPTION
We currently cache universes based on version integer so we
need to use a version number that does not clash with any
possible real universe.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
