### PR TITLE
DM-34954: Fix Instrument.from_string see also section

### DIFF
--- a/python/lsst/pipe/base/_instrument.py
+++ b/python/lsst/pipe/base/_instrument.py
@@ -217,7 +217,7 @@ class Instrument(metaclass=ABCMeta):
 
         See Also
         --------
-        Instrument.fromName()
+        Instrument.fromName
         """
         if "." not in name and registry is not None:
             try:


### PR DESCRIPTION
Numpydoc 1.2 was showing this See Also section with an extra `()` as an error instead of a warning.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
