### PR TITLE
DM-35697: Deprecate lsst.pipe.base.cmdLineTask.profile

### DIFF
--- a/doc/changes/DM-35697.removal.rst
+++ b/doc/changes/DM-35697.removal.rst
@@ -1,0 +1,2 @@
+Relocated ``lsst.pipe.base.cmdLineTask.profile`` to ``lsst.utils.timer.profile``.
+This was relocated as part of the Gen2 removal that includes the removal of ``CmdLineTask``.

--- a/python/lsst/pipe/base/cmdLineTask.py
+++ b/python/lsst/pipe/base/cmdLineTask.py
@@ -28,6 +28,11 @@ from deprecated.sphinx import deprecated
 from .task import Task
 
 
+@deprecated(
+    reason="Replaced by lsst.utils.timer.profile().  Will be removed after v26.0",
+    version="v25.0",
+    category=FutureWarning,
+)
 @contextlib.contextmanager
 def profile(filename, log=None):
     """Context manager for profiling with cProfile.


### PR DESCRIPTION
It has now moved to lsst.utils.timer.profile. (lsst/utils#131)

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
