### PR TITLE
DM-35721: Fix bug in PipelineTask test utilities

### DIFF
--- a/DM-35721.bugfix.rst
+++ b/DM-35721.bugfix.rst
@@ -1,0 +1,1 @@
+lsst.pipe.base.testUtils.makeQuantum no longer crashes if given a connection that is set to a dataset component.

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -259,12 +259,7 @@ def _refFromConnection(
     _checkDimensionsMatch(universe, set(connection.dimensions), dataId.keys())
     dataId = DataCoordinate.standardize(dataId, **kwargs, universe=universe)
 
-    # skypix is a PipelineTask alias for "some spatial index", Butler doesn't
-    # understand it. Code copied from TaskDatasetTypes.fromTaskDef
-    if "skypix" in connection.dimensions:
-        datasetType = butler.registry.getDatasetType(connection.name)
-    else:
-        datasetType = connection.makeDatasetType(universe)
+    datasetType = butler.registry.getDatasetType(connection.name)
 
     try:
         butler.registry.getDatasetType(datasetType.name)


### PR DESCRIPTION
This PR fixes a bug which caused `testUtils.makeQuantum` to crash when given a connection that pointed to a dataset component.