### PR TITLE
DM-4551: Add support for storage class conversion on get from in-memory dataset handle

### DIFF
--- a/doc/changes/DM-4551.api.rst
+++ b/doc/changes/DM-4551.api.rst
@@ -1,0 +1,1 @@
+``InMemoryDatasetHandle`` now supports storage class conversion on ``get()``.


### PR DESCRIPTION
This matches the change to DeferredDatasetHandle (lsst/daf_butler#737)

@TallJimbo you probably should look at this and the new deferred dataset handle changes in daf_butler given I had completely forgotten about this when you did your original review.



## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
