### PR TITLE
DM-36080: Remove an assert against component outputs.

### DIFF
--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -909,7 +909,10 @@ class _PipelineScaffolding:
                 )
                 isInit = datasetType in self.initIntermediates or datasetType in self.initOutputs
                 subset = commonDataIds.subset(datasetType.dimensions, unique=True)
-                assert not datasetType.isComponent(), "Output datasets cannot be components."
+                # TODO: this assert incorrectly bans component inputs;
+                # investigate on DM-33027.
+                # assert not datasetType.isComponent(), \
+                #     "Output datasets cannot be components."
 
                 # look at RUN collection first
                 if run is not None:


### PR DESCRIPTION
The assert inadvertently catches component *inputs* because of an unidentified bug elsewhere. This breaks all pipelines that use the default config for `ip.diffim.GetTemplateTask`.