### PR TITLE
DM-36487: Support bind values with user query in GraphBuilder

### DIFF
--- a/doc/changes/DM-36487.api.md
+++ b/doc/changes/DM-36487.api.md
@@ -1,0 +1,1 @@
+`GraphBuilder.makeGraph` method adds `bind` parameter for bind values to use with the user expression.

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -659,6 +659,7 @@ class _PipelineScaffolding:
         userQuery: Optional[str],
         externalDataId: DataCoordinate,
         datasetQueryConstraint: DatasetQueryConstraintVariant = DatasetQueryConstraintVariant.ALL,
+        bind: Optional[Mapping[str, Any]] = None,
     ) -> Iterator[DataCoordinateQueryResults]:
         """Query for the data IDs that connect nodes in the `QuantumGraph`.
 
@@ -683,6 +684,9 @@ class _PipelineScaffolding:
             The query constraint variant that should be used to constraint the
             query based on dataset existance, defaults to
             `DatasetQueryConstraintVariant.ALL`.
+        bind : `Mapping`, optional
+            Mapping containing literal values that should be injected into the
+            ``userQuery`` expression, keyed by the identifiers they replace.
 
         Returns
         -------
@@ -709,6 +713,7 @@ class _PipelineScaffolding:
             "dimensions": self.dimensions,
             "where": userQuery,
             "dataId": externalDataId,
+            "bind": bind,
         }
         if datasetQueryConstraint == DatasetQueryConstraintVariant.ALL:
             _LOG.debug("Constraining graph query using all datasets in pipeline.")
@@ -1287,6 +1292,7 @@ class GraphBuilder:
         datasetQueryConstraint: DatasetQueryConstraintVariant = DatasetQueryConstraintVariant.ALL,
         metadata: Optional[Mapping[str, Any]] = None,
         resolveRefs: bool = False,
+        bind: Optional[Mapping[str, Any]] = None,
     ) -> QuantumGraph:
         """Create execution graph for a pipeline.
 
@@ -1315,6 +1321,9 @@ class GraphBuilder:
             If `True` then resolve all input references and generate random
             dataset IDs for all output and intermediate datasets. True value
             requires ``run`` collection to be specified.
+        bind : `Mapping`, optional
+            Mapping containing literal values that should be injected into the
+            ``userQuery`` expression, keyed by the identifiers they replace.
 
         Returns
         -------
@@ -1348,7 +1357,7 @@ class GraphBuilder:
         else:
             dataId = DataCoordinate.makeEmpty(self.registry.dimensions)
         with scaffolding.connectDataIds(
-            self.registry, collections, userQuery, dataId, datasetQueryConstraint
+            self.registry, collections, userQuery, dataId, datasetQueryConstraint, bind
         ) as commonDataIds:
             condition = datasetQueryConstraint == DatasetQueryConstraintVariant.ALL
             scaffolding.resolveDatasetRefs(

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -27,7 +27,8 @@ __all__ = ["AddTaskConfig", "AddTask", "AddTaskFactoryMock"]
 
 import itertools
 import logging
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Type, Union, cast
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union, cast
 
 import lsst.daf.butler.tests as butlerTests
 import lsst.pex.config as pexConfig
@@ -361,6 +362,7 @@ def makeSimpleQGraph(
     datasetQueryConstraint: DSQVariant = DSQVariant.ALL,
     makeDatastoreRecords: bool = False,
     resolveRefs: bool = False,
+    bind: Optional[Mapping[str, Any]] = None,
 ) -> Tuple[Butler, QuantumGraph]:
     """Make simple QuantumGraph for tests.
 
@@ -409,6 +411,9 @@ def makeSimpleQGraph(
     resolveRefs : `bool`, optional
         If `True` then resolve all input references and generate random dataset
         IDs for all output and intermediate datasets.
+    bind : `Mapping`, optional
+        Mapping containing literal values that should be injected into the
+        ``userQuery`` expression, keyed by the identifiers they replace.
 
     Returns
     -------
@@ -439,10 +444,11 @@ def makeSimpleQGraph(
         datastore=butler.datastore if makeDatastoreRecords else None,
     )
     _LOG.debug(
-        "Calling GraphBuilder.makeGraph, collections=%r, run=%r, userQuery=%r",
+        "Calling GraphBuilder.makeGraph, collections=%r, run=%r, userQuery=%r bind=%s",
         butler.collections,
         run or butler.run,
         userQuery,
+        bind,
     )
     qgraph = builder.makeGraph(
         pipeline,
@@ -451,6 +457,7 @@ def makeSimpleQGraph(
         userQuery=userQuery,
         datasetQueryConstraint=datasetQueryConstraint,
         resolveRefs=resolveRefs,
+        bind=bind,
     )
 
     return butler, qgraph

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -66,6 +66,21 @@ class GraphBuilderTestCase(unittest.TestCase):
             with self.assertRaises(UserExpressionError):
                 simpleQGraph.makeSimpleQGraph(root=root, pipeline=pipeline, userQuery="instrument = 'foo'")
 
+    def testUserQueryBind(self):
+        """Verify that bind values work for user query."""
+        pipeline = simpleQGraph.makeSimplePipeline(
+            nQuanta=5, instrument="lsst.pipe.base.tests.simpleQGraph.SimpleInstrument"
+        )
+        instr = simpleQGraph.SimpleInstrument.getName()
+        # With a literal in the user query
+        with temporaryDirectory() as root:
+            simpleQGraph.makeSimpleQGraph(root=root, pipeline=pipeline, userQuery=f"instrument = '{instr}'")
+        # With a bind for the user query
+        with temporaryDirectory() as root:
+            simpleQGraph.makeSimpleQGraph(
+                root=root, pipeline=pipeline, userQuery="instrument = instr", bind={"instr": instr}
+            )
+
     def test_datastore_records(self):
         """Test for generating datastore records."""
         with temporaryDirectory() as root:


### PR DESCRIPTION
The `makeGraph` method adds a parameter for a bind mapping and passes that to a Registry query method.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
