### PR TITLE
DM-37582: Allow resolved refs in execution butler builder

### DIFF
--- a/doc/changes/DM-37582.feature.md
+++ b/doc/changes/DM-37582.feature.md
@@ -1,0 +1,1 @@
+`buildExecutionButler` method now supports input graph with all dataset references resolved.


### PR DESCRIPTION
Previously execution butler builder used dataset ID to check dataset existence. We enabled resolved references for all dataset refs in a graph to support QBB. Builder code is updated to check dataset existence by querying datastore, this is less efficient, but we hope to retire execution butler soon.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
