### PR TITLE
DM-38210: Use butler.get() instead of deprecated getDirect()

### DIFF
--- a/python/lsst/pipe/base/butlerQuantumContext.py
+++ b/python/lsst/pipe/base/butlerQuantumContext.py
@@ -130,12 +130,12 @@ class ButlerQuantumContext:
         # raise appropriately, so no need for us to do that here.
         if isinstance(ref, DeferredDatasetRef):
             self._checkMembership(ref.datasetRef, self.allInputs)
-            return self.__butler.getDirectDeferred(ref.datasetRef)
+            return self.__butler.getDeferred(ref.datasetRef)
         elif ref is None:
             return None
         else:
             self._checkMembership(ref, self.allInputs)
-            return self.__butler.getDirect(ref)
+            return self.__butler.get(ref)
 
     def _put(self, value: Any, ref: DatasetRef) -> None:
         """Store data in butler"""

--- a/python/lsst/pipe/base/butlerQuantumContext.py
+++ b/python/lsst/pipe/base/butlerQuantumContext.py
@@ -142,11 +142,13 @@ class ButlerQuantumContext:
         self._checkMembership(ref, self.allOutputs)
         if self.__full_butler is not None:
             # If reference is resolved we need to unresolved it first.
+            # It is possible that we are putting a dataset into a different
+            # run than what was originally expected.
             if ref.id is not None:
                 ref = ref.unresolved()
             self.__full_butler.put(value, ref)
         else:
-            self.__butler.putDirect(value, ref)
+            self.__butler.put(value, ref)
 
     def get(
         self,

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -56,17 +56,10 @@ class ButlerMock:
         return None
 
     def put(self, inMemoryDataset: Any, dsRef: DatasetRef, producer: Any = None):
-        # put requires unresolved ref
-        assert dsRef.id is None
         key = dsRef.dataId
         name = dsRef.datasetType.name
         dsdata = self.datasets.setdefault(name, {})
         dsdata[key] = inMemoryDataset
-
-    def putDirect(self, obj: Any, ref: DatasetRef):
-        # putDirect requires resolved ref
-        assert ref.id is not None
-        self.put(obj, ref.unresolved())
 
 
 class AddConnections(pipeBase.PipelineTaskConnections, dimensions=["instrument", "visit"]):
@@ -182,7 +175,7 @@ class PipelineTaskTestCase(unittest.TestCase):
         dstype0 = connections.input.makeDatasetType(butler.registry.dimensions)
         for i, quantum in enumerate(quanta):
             ref = quantum.inputs[dstype0.name][0]
-            butler.putDirect(100 + i, ref)
+            butler.put(100 + i, ref)
 
         # run task on each quanta
         checked_get = False
@@ -265,7 +258,7 @@ class PipelineTaskTestCase(unittest.TestCase):
         dstype0 = task1Connections.input.makeDatasetType(butler.registry.dimensions)
         for i, quantum in enumerate(quanta1):
             ref = quantum.inputs[dstype0.name][0]
-            butler.putDirect(100 + i, ref)
+            butler.put(100 + i, ref)
 
         butler_qc_factory = (
             pipeBase.ButlerQuantumContext.from_full
@@ -313,7 +306,7 @@ class PipelineTaskTestCase(unittest.TestCase):
         # add input data to butler
         dstype0 = connections.input.makeDatasetType(butler.registry.dimensions)
         ref = quantum.inputs[dstype0.name][0]
-        butler.putDirect(100, ref)
+        butler.put(100, ref)
 
         butlerQC = pipeBase.ButlerQuantumContext.from_full(butler, quantum)
 

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -47,8 +47,8 @@ class ButlerMock:
         self.datasets: dict[str, dict[DataCoordinate, Any]] = {}
         self.registry = SimpleNamespace(dimensions=DimensionUniverse())
 
-    def getDirect(self, ref: DatasetRef) -> Any:
-        # getDirect requires resolved ref
+    def get(self, ref: DatasetRef) -> Any:
+        # Requires resolved ref.
         assert ref.id is not None
         dsdata = self.datasets.get(ref.datasetType.name)
         if dsdata:


### PR DESCRIPTION
Depends on lsst/daf_butler#797

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
