### PR TITLE
DM-38091: Allow InMemoryDatasetHandle to take kwargs for dataId

### DIFF
--- a/doc/changes/DM-38091.feature.rst
+++ b/doc/changes/DM-38091.feature.rst
@@ -1,0 +1,1 @@
+Modified ``InMemoryDatasetHandle`` to allow it to be constructed with keyword arguments that will be converted to the relevant DataId.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,5 @@ write_to = "python/lsst/pipe/base/version.py"
 [tool.pytest.ini_options]
 addopts = "--flake8"
 flake8-ignore = ["E203", "W503", "N802", "N803", "N806", "N812", "N815", "N816"]
+# Some unit tests open registry database and don't close it.
+open_files_ignore = ["gen3.sqlite3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "networkx",
     "pyyaml >= 5.1",
     "numpy >= 1.17",
+    "frozendict",
 ]
 
 dynamic = ["version"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,3 @@ git+https://github.com/lsst/utils@main#egg=lsst-utils
 git+https://github.com/lsst/resources@main#egg=lsst-resources
 git+https://github.com/lsst/pex_config@main#egg=lsst-pex-config
 git+https://github.com/lsst/daf_relation@main#egg=lsst-daf-relation
-sqlalchemy >= 1.4, <2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ pyyaml >= 5.1
 pydantic
 numpy >= 1.17
 networkx
+frozendict
 git+https://github.com/lsst/daf_butler@main#egg=lsst-daf-butler
 git+https://github.com/lsst/utils@main#egg=lsst-utils
 git+https://github.com/lsst/resources@main#egg=lsst-resources

--- a/tests/test_dataset_handle.py
+++ b/tests/test_dataset_handle.py
@@ -105,6 +105,18 @@ class TestDatasetHandle(unittest.TestCase):
         hdl = InMemoryDatasetHandle(42, dataId=dataId)
         self.assertIs(hdl.dataId, dataId)
 
+        dataId = {"tract": 5, "patch": 2, "instrument": "TestCam"}
+        hdl = InMemoryDatasetHandle(42, **dataId)
+        self.assertEqual(hdl.dataId, dataId)
+
+        hdl = InMemoryDatasetHandle(42, dataId=dataId, tract=6)
+        self.assertEqual(hdl.dataId["tract"], 6)
+
+        dataId = DataCoordinate.standardize({}, universe=DimensionUniverse(), instrument="DummyCam")
+        hdl = InMemoryDatasetHandle(42, dataId=dataId, physical_filter="g")
+        self.assertIsInstance(hdl.dataId, DataCoordinate)
+        self.assertEqual(hdl.dataId["physical_filter"], "g")
+
     def test_dataset_handle_metric(self):
         metric = MetricsExample(summary={"a": 1, "b": 2}, output={"c": {"d": 5}}, data=[1, 2, 3, 4])
 


### PR DESCRIPTION
Some test users like to specify tract=N for example and don't want to have to decide whether they are
using a full DataCoordinate or an emulated one.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
