### PR TITLE
DM-38814: Drop obscore manager from config when making execution butler

### DIFF
--- a/python/lsst/pipe/base/executionButlerBuilder.py
+++ b/python/lsst/pipe/base/executionButlerBuilder.py
@@ -308,6 +308,9 @@ def _setupNewButler(
     # Remove any namespace that may be set in main registry.
     config.pop(("registry", "namespace"), None)
 
+    # Obscore manager cannot be used with execution butler.
+    config.pop(("registry", "managers", "obscore"), None)
+
     # record the current root of the datastore if it is specified relative
     # to the butler root
     if datastoreRoot is not None:

--- a/tests/config/butler-obscore.yaml
+++ b/tests/config/butler-obscore.yaml
@@ -1,0 +1,22 @@
+registry:
+  managers:
+    obscore:
+      cls: lsst.daf.butler.registry.obscore._manager.ObsCoreLiveTableManager
+      config:
+        namespace: "daf_butler_obscore"
+        version: 0
+        table_name: obscore
+        collection_type: RUN
+        facility_name: daf_butler_test
+        obs_collection: daf_butler_obs_collection
+        collections: []
+        use_butler_uri: false
+        dataset_types:
+          raw:
+            dataproduct_type: image
+            dataproduct_subtype: lsst.raw
+            calib_level: 1
+            obs_id_fmt: "{records[exposure].obs_id}-{records[detector].full_name}"
+            o_ucd: phot.count
+            access_format: image/fits
+            datalink_url_fmt: "https://data.lsst.cloud/api/datalink/links?ID=butler%3A//dp02/{id}"

--- a/tests/test_executionButler.py
+++ b/tests/test_executionButler.py
@@ -1,0 +1,60 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for execution butler."""
+
+import os
+import unittest
+
+import lsst.utils.tests
+from lsst.daf.butler import Butler
+from lsst.pipe.base.executionButlerBuilder import buildExecutionButler
+from lsst.pipe.base.tests import simpleQGraph
+from lsst.utils.tests import temporaryDirectory
+
+TESTDIR = os.path.abspath(os.path.dirname(__file__))
+
+
+class ExecutionTestCase(unittest.TestCase):
+    """Small bunch of tests for instantiating execution butler."""
+
+    def test_simple(self) -> None:
+        """Test buildExecutionButler with default butler config."""
+        with temporaryDirectory() as root:
+            butler, qgraph = simpleQGraph.makeSimpleQGraph(root=root, inMemory=False)
+            buildExecutionButler(butler, qgraph, os.path.join(root, "exec_butler"), butler.run)
+
+    def test_obscore(self) -> None:
+        """Test buildExecutionButler with obscore table in the butler."""
+        with temporaryDirectory() as root:
+            config = os.path.join(TESTDIR, "config/butler-obscore.yaml")
+            butler = simpleQGraph.makeSimpleButler(root=root, inMemory=False, config=config)
+            butler, qgraph = simpleQGraph.makeSimpleQGraph(butler=butler)
+
+            # Need a fresh butler instance to make sure it reads config from
+            # butler.yaml, which does not have full obscore config.
+            butler = Butler(root, run=butler.run)
+            buildExecutionButler(butler, qgraph, os.path.join(root, "exec_butler"), butler.run)
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
The fix is one additional line `executionButlerBuilder.py`, the rest is
a new unit test to reproduce the problem with execution butler and obscore.

Also needs lsst/daf_butler#826

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
