### PR TITLE
DM-38888: Fix composite-component comparisons in execution butler creation.

### DIFF
--- a/doc/changes/DM-38888.bugfix.md
+++ b/doc/changes/DM-38888.bugfix.md
@@ -1,0 +1,1 @@
+Fix bug related to checking component datasets in execution butler creation, introduced in DM-38614.


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
