### PR TITLE
DM-38957: Ignore new data IDs in QG gen follow-up queries.

### DIFF
--- a/python/lsst/pipe/base/_dataset_handle.py
+++ b/python/lsst/pipe/base/_dataset_handle.py
@@ -204,7 +204,7 @@ class InMemoryDatasetHandle:
     """The object to store in this dataset handle for later retrieval.
     """
 
-    dataId: DataCoordinate | frozendict  # type:ignore
+    dataId: DataCoordinate | frozendict
     """The `~lsst.daf.butler.DataCoordinate` associated with this dataset
     handle.
     """

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -1097,7 +1097,8 @@ class _PipelineScaffolding:
                     except MissingDatasetTypeError:
                         resolvedRefQueryResults = []
                     for resolvedRef in resolvedRefQueryResults:
-                        assert resolvedRef.dataId in refs
+                        if resolvedRef.dataId not in refs:
+                            continue
                         refs[resolvedRef.dataId].ref = (
                             resolvedRef.makeComponentRef(component) if component is not None else resolvedRef
                         )
@@ -1127,6 +1128,8 @@ class _PipelineScaffolding:
             dataIdsNotFoundYet = set(refs.keys())
             for resolvedRef in resolvedRefQueryResults:
                 dataIdsNotFoundYet.discard(resolvedRef.dataId)
+                if resolvedRef.dataId not in refs:
+                    continue
                 refs[resolvedRef.dataId].ref = (
                     resolvedRef if component is None else resolvedRef.makeComponentRef(component)
                 )


### PR DESCRIPTION
These data IDs that were not present in the initial data ID query can come about because we have to drop the post-query region-filtering when doing the follow-up queries for datasets.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
