### PR TITLE
DM-39122: Remove UnresolvedRefWarning filters

### DIFF
--- a/python/lsst/pipe/base/graph/quantumNode.py
+++ b/python/lsst/pipe/base/graph/quantumNode.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 __all__ = ("QuantumNode", "NodeId", "BuildId")
 
 import uuid
-import warnings
 from dataclasses import dataclass
 from typing import Any, Dict, NewType, Optional, Tuple
 
@@ -34,7 +33,6 @@ from lsst.daf.butler import (
     DimensionUniverse,
     Quantum,
     SerializedQuantum,
-    UnresolvedRefWarning,
 )
 from pydantic import BaseModel
 
@@ -137,15 +135,13 @@ class QuantumNode:
         universe: DimensionUniverse,
         recontitutedDimensions: Optional[Dict[int, Tuple[str, DimensionRecord]]] = None,
     ) -> QuantumNode:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", category=UnresolvedRefWarning)
-            return QuantumNode(
-                quantum=Quantum.from_simple(
-                    simple.quantum, universe, reconstitutedDimensions=recontitutedDimensions
-                ),
-                taskDef=taskDefMap[simple.taskLabel],
-                nodeId=simple.nodeId,
-            )
+        return QuantumNode(
+            quantum=Quantum.from_simple(
+                simple.quantum, universe, reconstitutedDimensions=recontitutedDimensions
+            ),
+            taskDef=taskDefMap[simple.taskLabel],
+            nodeId=simple.nodeId,
+        )
 
 
 class SerializedQuantumNode(BaseModel):


### PR DESCRIPTION
De-serialization code now expects that all serialized refs are resolved.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
