### PR TITLE
DM-39198: Ensure task connection storage classes are used in Quanta.

### DIFF
--- a/doc/changes/DM-39198.bugfix.md
+++ b/doc/changes/DM-39198.bugfix.md
@@ -1,0 +1,3 @@
+Fix handling of storage classes in QuantumGraph generation.
+
+This could lead to a failure downstream in execution butler creation, and would likely have led to problems with Quantum-Backed Butler usage as well.

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -269,7 +269,7 @@ class _DatasetDict(NamedKeyDict[DatasetType, dict[DataCoordinate, _RefHolder]]):
 
     def unpackMultiRefs(self, storage_classes: dict[str, str]) -> NamedKeyDict[DatasetType, list[DatasetRef]]:
         """Unpack nested multi-element `DatasetRef` dicts into a new
-        mapping with `DatasetType` keys and `set` of `DatasetRef` values.
+        mapping with `DatasetType` keys and `list` of `DatasetRef` values.
 
         Parameters
         ----------


### PR DESCRIPTION
QuantumGraph should have the connection storage classes in its Quantum objects, and the registry storage classes for those dataset types in its "registryDatasetTypes" attribute.  Apparently we were making no effort to ensure the former before.

## Checklist

- [x] ran [Jenkins](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/38768/pipeline)
- [x] added a release note for user-visible changes to `doc/changes`
