### PR TITLE
DM-39276: Address docstring typo in pipe_base config.py

### DIFF
--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -218,7 +218,7 @@ class PipelineTaskConfig(pexConfig.Config, metaclass=PipelineTaskConfigMeta):
         r"""Apply config overrides to this config instance.
 
         Parameters
-        ---------
+        ----------
         instrument : `Instrument` or `None`
             An instance of the `Instrument` specified in a pipeline.
             If `None` then the pipeline did not specify and instrument.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
