### PR TITLE
DM-37704: Update code to use resolved refs.

### DIFF
--- a/doc/changes/DM-37704.api.md
+++ b/doc/changes/DM-37704.api.md
@@ -1,0 +1,2 @@
+* `ButlerQuantumContext` is updated to only need a `LimitedButler`.
+* Factory methods `from_full` and `from_limited` were dropped, a constructor accepting a `LimitedButler` instance is now used to make instances.

--- a/python/lsst/pipe/base/executionButlerBuilder.py
+++ b/python/lsst/pipe/base/executionButlerBuilder.py
@@ -164,12 +164,9 @@ def _accumulate(
                 if not isinstance(refs, list):
                     refs = [refs]
                 for ref in refs:
-                    if ref.id is not None:
-                        # We could check existence of individual components,
-                        # but it should be less work to check their parent.
-                        if ref.isComponent():
-                            ref = ref.makeCompositeRef()
-                        check_refs.add(ref)
+                    if ref.isComponent():
+                        ref = ref.makeCompositeRef()
+                    check_refs.add(ref)
     exist_map = butler.datastore.knows_these(check_refs)
     existing_ids = set(ref.id for ref, exists in exist_map.items() if exists)
     del exist_map
@@ -189,7 +186,7 @@ def _accumulate(
                 for ref in refs:
                     # Component dataset ID is the same as its parent ID, so
                     # checking component in existing_ids works OK.
-                    if ref.id is not None and ref.id in existing_ids:
+                    if ref.id in existing_ids:
                         # If this is a component we want the composite to be
                         # exported.
                         if ref.isComponent():
@@ -351,7 +348,7 @@ def _import(
     # because execution butler is assumed to be able to see all the file
     # locations that the main datastore can see. "split" supports some
     # absolute URIs in the datastore.
-    newButler.import_(filename=yamlBuffer, format="yaml", reuseIds=True, transfer="split")
+    newButler.import_(filename=yamlBuffer, format="yaml", transfer="split")
 
     # If there is modifier callable, run it to make necessary updates
     # to the new butler.

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -434,7 +434,7 @@ class _QuantumScaffolding:
             quantum_records = {}
             input_refs = list(itertools.chain.from_iterable(helper.inputs.values()))
             input_refs += list(initInputs.values())
-            input_ids = set(ref.id for ref in input_refs if ref.id is not None)
+            input_ids = set(ref.id for ref in input_refs)
             for datastore_name, records in datastore_records.items():
                 matching_records = records.subset(input_ids)
                 if matching_records is not None:
@@ -621,7 +621,6 @@ class _DatasetIdMaker:
             if key not in self.resolved:
                 raise ValueError(f"Composite dataset is missing from cache: {parent_type} {data_id}")
             parent_ref = self.resolved[key]
-            assert parent_ref.id is not None and parent_ref.run is not None, "parent ref must be resolved"
             return DatasetRef(dataset_type, data_id, id=parent_ref.id, run=parent_ref.run, conform=False)
 
         key = dataset_type, data_id

--- a/python/lsst/pipe/base/script/transfer_from_graph.py
+++ b/python/lsst/pipe/base/script/transfer_from_graph.py
@@ -86,7 +86,7 @@ def transfer_from_graph(
     # Make QBB, its config is the same as output Butler.
     qbb = QuantumBackedButler.from_predicted(
         config=dest,
-        predicted_inputs=[ref.getCheckedId() for ref in output_refs],
+        predicted_inputs=[ref.id for ref in output_refs],
         predicted_outputs=[],
         dimensions=qgraph.universe,
         datastore_records={},

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -303,7 +303,7 @@ def runTestQuantum(
         If ``mockRun`` is set, the mock that replaced ``run``. This object can
         be queried for the arguments ``runQuantum`` passed to ``run``.
     """
-    butlerQc = ButlerQuantumContext.from_full(butler, quantum)
+    butlerQc = ButlerQuantumContext(butler, quantum)
     # This is a type ignore, because `connections` is a dynamic class, but
     # it for sure will have this property
     connections = task.config.ConnectionsClass(config=task.config)  # type: ignore

--- a/tests/test_graphBuilder.py
+++ b/tests/test_graphBuilder.py
@@ -134,34 +134,6 @@ class GraphBuilderTestCase(unittest.TestCase):
                     else:
                         self.assertEqual(quantum.datastore_records, {})
 
-    def testResolveRefs(self):
-        """Test for GraphBuilder returning graph with all resolved refs."""
-
-        def _assert_resolved(refs):
-            self.assertTrue(all(ref.id is not None for ref in refs))
-
-        with temporaryDirectory() as root:
-            _, qgraph = simpleQGraph.makeSimpleQGraph(root=root)
-            self.assertEqual(len(qgraph), 5)
-
-            # check per-quantum inputs/outputs
-            for node in qgraph:
-                quantum = node.quantum
-                for datasetType, refs in quantum.inputs.items():
-                    _assert_resolved(refs)
-                for datasetType, refs in quantum.outputs.items():
-                    _assert_resolved(refs)
-
-            # check per-task init-inputs/init-outputs
-            for taskDef in qgraph.iterTaskGraph():
-                if (refs := qgraph.initInputRefs(taskDef)) is not None:
-                    _assert_resolved(refs)
-                if (refs := qgraph.initOutputRefs(taskDef)) is not None:
-                    _assert_resolved(refs)
-
-            # check global init-outputs
-            _assert_resolved(qgraph.globalInitOutputRefs())
-
 
 if __name__ == "__main__":
     lsst.utils.tests.init()

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -41,8 +41,6 @@ class ButlerMock:
         self.registry = SimpleNamespace(dimensions=DimensionUniverse())
 
     def get(self, ref: DatasetRef) -> Any:
-        # Requires resolved ref.
-        assert ref.id is not None
         dsdata = self.datasets.get(ref.datasetType.name)
         if dsdata:
             return dsdata.get(ref.dataId)

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -159,10 +159,7 @@ class PipelineTaskTestCase(unittest.TestCase):
         # run task on each quanta
         checked_get = False
         for quantum in quanta:
-            if full_butler:
-                butlerQC = pipeBase.ButlerQuantumContext.from_full(butler, quantum)
-            else:
-                butlerQC = pipeBase.ButlerQuantumContext.from_limited(butler, quantum)
+            butlerQC = pipeBase.ButlerQuantumContext(butler, quantum)
             inputRefs, outputRefs = connections.buildDatasetRefs(quantum)
             task.runQuantum(butlerQC, inputRefs, outputRefs)
 
@@ -239,19 +236,13 @@ class PipelineTaskTestCase(unittest.TestCase):
             ref = quantum.inputs[dstype0.name][0]
             butler.put(100 + i, ref)
 
-        butler_qc_factory = (
-            pipeBase.ButlerQuantumContext.from_full
-            if full_butler
-            else pipeBase.ButlerQuantumContext.from_limited
-        )
-
         # run task on each quanta
         for quantum in quanta1:
-            butlerQC = butler_qc_factory(butler, quantum)
+            butlerQC = pipeBase.ButlerQuantumContext(butler, quantum)
             inputRefs, outputRefs = connections1.buildDatasetRefs(quantum)
             task1.runQuantum(butlerQC, inputRefs, outputRefs)
         for quantum in quanta2:
-            butlerQC = butler_qc_factory(butler, quantum)
+            butlerQC = pipeBase.ButlerQuantumContext(butler, quantum)
             inputRefs, outputRefs = connections2.buildDatasetRefs(quantum)
             task2.runQuantum(butlerQC, inputRefs, outputRefs)
 
@@ -287,7 +278,7 @@ class PipelineTaskTestCase(unittest.TestCase):
         ref = quantum.inputs[dstype0.name][0]
         butler.put(100, ref)
 
-        butlerQC = pipeBase.ButlerQuantumContext.from_full(butler, quantum)
+        butlerQC = pipeBase.ButlerQuantumContext(butler, quantum)
 
         # Pass ref as single argument or a list.
         obj = butlerQC.get(ref)


### PR DESCRIPTION
All references are now resolved, retiring the code that checked for unresolved refs.

ButlerQuantumContext interface is updated. The constructor now takes a
LimitedButler instance only and factory methods `from_full` and `from_limited` are gone.

## Checklist

- [X] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
