### PR TITLE
DM-39453: Add convenience method to get default dimension packers.

### DIFF
--- a/doc/changes/DM-39453.feature.md
+++ b/doc/changes/DM-39453.feature.md
@@ -1,0 +1,1 @@
+Add `Instrument.make_default_dimension_packer` to restore simple access to the default data ID packer for an instrument.

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -208,8 +208,14 @@ class InstrumentTestCase(unittest.TestCase):
             # Note that we don't need to pass any more than the instrument in
             # the data ID yet, because we're just constructing packers, not
             # calling their pack method.
-            visit_packers=[config.packer.apply(instrument_data_id, is_exposure=False)],
-            exposure_packers=[config.packer.apply(instrument_data_id, is_exposure=True)],
+            visit_packers=[
+                config.packer.apply(instrument_data_id, is_exposure=False),
+                Instrument.make_default_dimension_packer(instrument_data_id, is_exposure=False),
+            ],
+            exposure_packers=[
+                config.packer.apply(instrument_data_id, is_exposure=True),
+                Instrument.make_default_dimension_packer(instrument_data_id, is_exposure=True),
+            ],
             n_detectors=record.detector_max,
             n_visits=record.visit_max,
             n_exposures=record.exposure_max,


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins ([underway](https://ci.lsst.codes/blue/organizations/jenkins/stack-os-matrix/detail/stack-os-matrix/38952/pipeline))
- [x] added a release note for user-visible changes to `doc/changes`
