### PR TITLE
DM-39760: Make NoDimensionsTask test utility consistent about storage classes.

### DIFF
--- a/python/lsst/pipe/base/tests/no_dimensions.py
+++ b/python/lsst/pipe/base/tests/no_dimensions.py
@@ -27,6 +27,7 @@ __all__ = (
     "NoDimensionsTestTask",
 )
 
+import dataclasses
 from typing import cast
 
 from lsst.pex.config import Field
@@ -51,13 +52,19 @@ class NoDimensionsTestConnections(PipelineTaskConnections, dimensions=set()):
         name="output", doc="some dict-y output data for testing", storageClass="StructuredDataDict"
     )
 
+    config: NoDimensionsTestConfig
+
+    def __init__(self, *, config: PipelineTaskConfig | None = None):
+        if self.config.outputSC != "StructuredDataDict":
+            self.output = dataclasses.replace(self.output, storageClass=self.config.outputSC)
+
 
 class NoDimensionsTestConfig(PipelineTaskConfig, pipelineConnections=NoDimensionsTestConnections):
     """Configuration for `NoDimensionTestTask`."""
 
     key = Field[str](doc="String key for the dict entry the task sets.", default="one")
     value = Field[int](doc="Integer value for the dict entry the task sets.", default=1)
-    outputSC = Field[str](doc="Output storage class requested", default="dict")
+    outputSC = Field[str](doc="Output storage class requested", default="StructuredDataDict")
 
 
 class NoDimensionsTestTask(PipelineTask):


### PR DESCRIPTION
The config option provided by this task to change its output storage class actually only changes the Python type returned, making that type inconsistent with the storage class it declared in its connections. This means we've long been testing essentially the wrong behavior.

This also switches the default for outputSC from 'dict' to 'StructuredDataDict', since it's supposed to be a storage class name, not a pytype.  This wasn't causing trouble, but it was very confusing.

## Checklist

- [x] ran Jenkins
- [ ] ~added a release note for user-visible changes to `doc/changes`~ (I'm considering this not-user-visible, I think?)
