### PR TITLE
DM-39902: add support for deprecating connections and connection templates

### DIFF
--- a/doc/changes/DM-39902
+++ b/doc/changes/DM-39902
@@ -1,0 +1,1 @@
+Make it possible to deprecate `PipelineTask` connections.

--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -146,7 +146,10 @@ class PipelineTaskConfigMeta(pexConfig.ConfigMeta):
                 docString = "Template parameter used to format corresponding field template parameter"
                 for templateName, default in connectionsClass.defaultTemplates.items():
                     configConnectionsNamespace[templateName] = TemplateField(
-                        dtype=str, doc=docString, default=default
+                        dtype=str,
+                        doc=docString,
+                        default=default,
+                        deprecated=connectionsClass.deprecatedTemplates.get(templateName),
                     )
             # add a reference to the connection class used to create this sub
             # config

--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -138,7 +138,7 @@ class PipelineTaskConfigMeta(pexConfig.ConfigMeta):
             configConnectionsNamespace: dict[str, pexConfig.Field] = {}
             for fieldName, obj in connectionsClass.allConnections.items():
                 configConnectionsNamespace[fieldName] = pexConfig.Field[str](
-                    doc=f"name for connection {fieldName}", default=obj.name
+                    doc=f"name for connection {fieldName}", default=obj.name, deprecated=obj.deprecated
                 )
             # If there are default templates also add them as fields to
             # configure the template values

--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -50,12 +50,19 @@ class BaseConnection:
         consistent (i.e. zip-iterable) in `PipelineTask.runQuantum()` and
         notify the execution system as early as possible of outputs that will
         not be produced because the corresponding input is missing.
+    deprecated : `str`, optional
+        A description of why this connection is deprecated, including the
+        version after which it may be removed.
+
+        If not `None`, the string is appended to the docstring for this
+        connection and the corresponding config Field.
     """
 
     name: str
     storageClass: str
     doc: str = ""
     multiple: bool = False
+    deprecated: str | None = dataclasses.field(default=None, kw_only=True)
 
     _connection_type_set: ClassVar[str]
 

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -224,14 +224,20 @@ class PipelineTaskConnectionsMetaclass(type):
             # look up any template from base classes and merge them all
             # together
             mergeDict = {}
+            mergeDeprecationsDict = {}
             for base in bases[::-1]:
                 if hasattr(base, "defaultTemplates"):
                     mergeDict.update(base.defaultTemplates)
+                if hasattr(base, "deprecatedTemplates"):
+                    mergeDeprecationsDict.update(base.deprecatedTemplates)
             if "defaultTemplates" in kwargs:
                 mergeDict.update(kwargs["defaultTemplates"])
-
+            if "deprecatedTemplates" in kwargs:
+                mergeDeprecationsDict.update(kwargs["deprecatedTemplates"])
             if len(mergeDict) > 0:
                 kwargs["defaultTemplates"] = mergeDict
+            if len(mergeDeprecationsDict) > 0:
+                kwargs["deprecatedTemplates"] = mergeDeprecationsDict
 
             # Verify that if templated strings were used, defaults were
             # supplied as an argument in the declaration of the connection
@@ -258,6 +264,7 @@ class PipelineTaskConnectionsMetaclass(type):
                         f" (conflicts are {nameTemplateIntersection})."
                     )
             dct["defaultTemplates"] = kwargs.get("defaultTemplates", {})
+            dct["deprecatedTemplates"] = kwargs.get("deprecatedTemplates", {})
 
         # Convert all the connection containers into frozensets so they cannot
         # be modified at the class scope

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -38,6 +38,7 @@ __all__ = [
 import dataclasses
 import itertools
 import string
+import warnings
 from collections import UserDict
 from collections.abc import Collection, Generator, Iterable, Mapping, Sequence, Set
 from dataclasses import dataclass
@@ -360,6 +361,12 @@ class PipelineTaskConnectionsMetaclass(type):
         # that.
         instance._allConnections.clear()
         instance._allConnections.update(updated_all_connections)
+
+        for obj in instance._allConnections.values():
+            if obj.deprecated is not None:
+                warnings.warn(
+                    obj.deprecated, FutureWarning, stacklevel=find_outside_stacklevel("lsst.pipe.base")
+                )
 
         # Freeze the connection instance dimensions now.  This at odds with the
         # type annotation, which says [mutable] `set`, just like the connection

--- a/python/lsst/pipe/base/graph/_implDetails.py
+++ b/python/lsst/pipe/base/graph/_implDetails.py
@@ -320,8 +320,8 @@ def _pruner(
                     taskClass=node.quantum.taskClass,
                     dataId=node.quantum.dataId,
                     initInputs=node.quantum.initInputs,
-                    inputs=helper.inputs,  # type: ignore
-                    outputs=helper.outputs,  # type: ignore
+                    inputs=helper.inputs,
+                    outputs=helper.outputs,
                 )
                 # If the inputs or outputs were adjusted to something different
                 # than what was supplied by the graph builder, dissassociate

--- a/python/lsst/pipe/base/graphBuilder.py
+++ b/python/lsst/pipe/base/graphBuilder.py
@@ -461,8 +461,8 @@ class _QuantumScaffolding:
             taskClass=self.task.taskDef.taskClass,
             dataId=self.dataId,
             initInputs=initInputs,
-            inputs=helper.inputs,  # type: ignore
-            outputs=helper.outputs,  # type: ignore
+            inputs=helper.inputs,
+            outputs=helper.outputs,
             datastore_records=quantum_records,
         )
 

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -187,10 +187,15 @@ class TestConnectionsClass(unittest.TestCase):
     def test_deprecation(self) -> None:
         """Test support for deprecating connections."""
 
-        class TestConnections(pipeBase.PipelineTaskConnections, dimensions=self.test_dims):
+        class TestConnections(
+            pipeBase.PipelineTaskConnections,
+            dimensions=self.test_dims,
+            defaultTemplates={"t1": "dataset_type_1"},
+            deprecatedTemplates={"t1": "Deprecated in v600, will be removed after v601."},
+        ):
             input1 = pipeBase.connectionTypes.Input(
                 doc="Docs for input1",
-                name="input1_dataset_type",
+                name="input1_{t1}",
                 storageClass="StructuredDataDict",
                 deprecated="Deprecated in v50000, will be removed after v50001.",
             )
@@ -204,7 +209,9 @@ class TestConnectionsClass(unittest.TestCase):
 
         config = TestConfig()
         with self.assertWarns(FutureWarning):
-            config.connections.input1 = "some_other_dataset_type"
+            config.connections.input1 = "dataset_type_2"
+        with self.assertWarns(FutureWarning):
+            config.connections.t1 = "dataset_type_3"
 
         with self.assertWarns(FutureWarning):
             TestConnections(config=config)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -27,6 +27,7 @@ import unittest
 import lsst.pipe.base as pipeBase
 import lsst.utils.tests
 import pytest
+from lsst.pex.config import Field
 
 
 class TestConnectionsClass(unittest.TestCase):
@@ -181,6 +182,24 @@ class TestConnectionsClass(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             pipeBase.connectionTypes.Output(Doc="mock doc", dimensions=1, name="output", storageClass="mock")
+
+    def test_deprecation(self) -> None:
+        """Test support for deprecating connections."""
+
+        class TestConnections(pipeBase.PipelineTaskConnections, dimensions=self.test_dims):
+            input1 = pipeBase.connectionTypes.Input(
+                doc="Docs for input1",
+                name="input1_dataset_type",
+                storageClass="StructuredDataDict",
+                deprecated="Deprecated in v50000, will be removed after v50001.",
+            )
+
+        class TestConfig(pipeBase.PipelineTaskConfig, pipelineConnections=TestConnections):
+            pass
+
+        config = TestConfig()
+        with self.assertWarns(FutureWarning):
+            config.connections.input1 = "some_other_dataset_type"
 
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
