### PR TITLE
DM-40198 Allow parameters to be used in Python/config block

### DIFF
--- a/doc/changes/DM-40198.feature.md
+++ b/doc/changes/DM-40198.feature.md
@@ -1,0 +1,1 @@
+Parameters defined in a Pipeline can now be used within a config python block as well as within config files loaded by a Pipeline.

--- a/python/lsst/pipe/base/config.py
+++ b/python/lsst/pipe/base/config.py
@@ -241,6 +241,7 @@ class PipelineTaskConfig(pexConfig.Config, metaclass=PipelineTaskConfigMeta):
             The label associated with this class's Task in a pipeline.
         """
         overrides = ConfigOverrides()
+        overrides.addParameters(parameters)
         if instrument is not None:
             overrides.addInstrumentOverride(instrument, taskDefaultName)
         if pipelineConfigs is not None:

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -227,7 +227,7 @@ class ParametersIR:
                         field2: parameters.shared_value
     """
 
-    mapping: MutableMapping[str, str]
+    mapping: MutableMapping[str, Any]
     """A mutable mapping of identifiers as keys, and shared configuration
     as values.
     """


### PR DESCRIPTION
Allow parameters defined in a Pipeline to be used withing a python config block, or a loaded config file.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
