### PR TITLE
DM-40243: Attempt to avoid unbounded refcat lookups in QG generation.

### DIFF
--- a/doc/changes/DM-40243.feature.md
+++ b/doc/changes/DM-40243.feature.md
@@ -1,0 +1,3 @@
+When looking up prerequisite inputs with skypix data IDs (e.g. reference catalogs) for a quantum whose data ID is not spatial, use the union of the spatial regions of the input and output datasets as a constraint.
+
+This keeps global sequence-point tasks from being given all such datasets in the input collections.


### PR DESCRIPTION
## Checklist

- [x] ran ~Jenkins~ local lsstsw
- [x] added a release note for user-visible changes to `doc/changes`
