### PR TITLE
DM-40254: Improve handling of calibration datasets in graph builder

### DIFF
--- a/doc/changes/DM-40254.bugfix.md
+++ b/doc/changes/DM-40254.bugfix.md
@@ -1,0 +1,2 @@
+Fix a bug in quantum graph builder which resulted in missing datastore records for calibration datasets.
+This bug was causing failures for pipetask execution with quantum-backed butler.


### PR DESCRIPTION
There may be multiple calibration datasets for the same dataset type and
data ID in one graph (with different timespans). This patch changes internal
graph builder structure for prerequisite datasets to allow multiple datasets
for one data ID.

## Checklist

- [ ] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
