### PR TITLE
DM-40367: Add connection name to deprecation warning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,11 +27,13 @@ jobs:
           channels: conda-forge,defaults
           channel-priority: strict
           show-channel-urls: true
+          miniforge-variant: Mambaforge
+          use-mamba: true
 
       - name: Update pip/wheel infrastructure
         shell: bash -l {0}
         run: |
-          conda install -y -q pip wheel
+          mamba install -y -q pip wheel
 
       - name: Install dependencies
         shell: bash -l {0}
@@ -43,13 +45,13 @@ jobs:
       - name: Install pytest packages
         shell: bash -l {0}
         run: |
-          conda install -y -q \
+          mamba install -y -q \
             pytest pytest-xdist pytest-openfiles pytest-cov
 
       - name: List installed packages
         shell: bash -l {0}
         run: |
-          conda list
+          mamba list
           pip list -v
 
       - name: Build and install

--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -30,6 +30,7 @@ from collections.abc import Callable, Iterable, Sequence
 from typing import ClassVar
 
 from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, DimensionUniverse, Registry, StorageClass
+from lsst.utils.introspection import find_outside_stacklevel
 
 
 @dataclasses.dataclass(frozen=True)
@@ -65,6 +66,13 @@ class BaseConnection:
     deprecated: str | None = dataclasses.field(default=None, kw_only=True)
 
     _connection_type_set: ClassVar[str]
+    _deprecation_context: str = ""
+
+    def __post_init__(self):
+        if self.deprecated and not self._deprecation_context:
+            info = {}
+            _ = find_outside_stacklevel("lsst.pipe.base", "dataclasses", stack_info=info)
+            object.__setattr__(self, "_deprecation_context", f"{info['filename']}:{info['lineno']}")
 
     def __get__(self, inst, klass):
         """Descriptor access method.

--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -147,6 +147,7 @@ class DimensionedConnection(BaseConnection):
     isCalibration: bool = False
 
     def __post_init__(self):
+        super().__post_init__()
         if isinstance(self.dimensions, str):
             raise TypeError(
                 "Dimensions must be iterable of dimensions, got str, possibly omitted trailing comma"

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -369,10 +369,11 @@ class PipelineTaskConnectionsMetaclass(type):
         instance._allConnections.clear()
         instance._allConnections.update(updated_all_connections)
 
-        for obj in instance._allConnections.values():
+        for connection_name, obj in instance._allConnections.items():
             if obj.deprecated is not None:
                 warnings.warn(
-                    f"{obj.name} (from {obj._deprecation_context}): {obj.deprecated}",
+                    f"Connection {connection_name} with datasetType {obj.name} "
+                    f"(from {obj._deprecation_context}): {obj.deprecated}",
                     FutureWarning,
                     stacklevel=1,  # Report from this location.
                 )

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -46,7 +46,6 @@ from types import MappingProxyType, SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 from lsst.daf.butler import DataCoordinate, DatasetRef, DatasetType, NamedKeyDict, NamedKeyMapping, Quantum
-from lsst.utils.introspection import find_outside_stacklevel
 
 from ._status import NoWorkFound
 from .connectionTypes import BaseConnection, BaseInput, Output, PrerequisiteInput
@@ -372,7 +371,9 @@ class PipelineTaskConnectionsMetaclass(type):
         for obj in instance._allConnections.values():
             if obj.deprecated is not None:
                 warnings.warn(
-                    obj.deprecated, FutureWarning, stacklevel=find_outside_stacklevel("lsst.pipe.base")
+                    f"{obj.name}: {obj.deprecated}",
+                    FutureWarning,
+                    stacklevel=1,  # Report from this location.
                 )
 
         # Freeze the connection instance dimensions now.  This at odds with the

--- a/python/lsst/pipe/base/connections.py
+++ b/python/lsst/pipe/base/connections.py
@@ -333,6 +333,7 @@ class PipelineTaskConnectionsMetaclass(type):
                     if connection.deprecated is None
                     else f"{connection.doc}\n{connection.deprecated}"
                 ),
+                _deprecation_context=connection._deprecation_context,
             )
             instance._allConnections[internal_name] = instance_connection
 
@@ -371,7 +372,7 @@ class PipelineTaskConnectionsMetaclass(type):
         for obj in instance._allConnections.values():
             if obj.deprecated is not None:
                 warnings.warn(
-                    f"{obj.name}: {obj.deprecated}",
+                    f"{obj.name} (from {obj._deprecation_context}): {obj.deprecated}",
                     FutureWarning,
                     stacklevel=1,  # Report from this location.
                 )

--- a/python/lsst/pipe/base/testUtils.py
+++ b/python/lsst/pipe/base/testUtils.py
@@ -308,8 +308,9 @@ def runTestQuantum(
     connections = task.config.ConnectionsClass(config=task.config)  # type: ignore
     inputRefs, outputRefs = connections.buildDatasetRefs(quantum)
     if mockRun:
-        with unittest.mock.patch.object(task, "run") as mock, unittest.mock.patch(
-            "lsst.pipe.base.QuantumContext.put"
+        with (
+            unittest.mock.patch.object(task, "run") as mock,
+            unittest.mock.patch("lsst.pipe.base.QuantumContext.put"),
         ):
             task.runQuantum(butlerQc, inputRefs, outputRefs)
             return mock

--- a/python/lsst/pipe/base/tests/mocks/_pipeline_task.py
+++ b/python/lsst/pipe/base/tests/mocks/_pipeline_task.py
@@ -277,7 +277,7 @@ class MockPipelineTaskConnections(BaseTestPipelineTaskConnections, dimensions=()
                 # registrations) has to be available whenever this dataset type
                 # is used.
                 storage_class = MockStorageClass.get_or_register_mock(connection.storageClass)
-                kwargs = {}
+                kwargs: dict[str, Any] = {}
                 if hasattr(connection, "dimensions"):
                     connection_dimensions = set(connection.dimensions)
                     # Replace the generic "skypix" placeholder with htm7, since


### PR DESCRIPTION
This provides some context. Also remove the find_outside_stacklevel because there is nothing in the stack trace that is relevant to the deprecation warning.

Depends on lsst/utils#168

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
