### PR TITLE
DM-40392: Re-implement QuantumGraph.updateRun method

### DIFF
--- a/doc/changes/DM-40392.bugfix.md
+++ b/doc/changes/DM-40392.bugfix.md
@@ -1,0 +1,1 @@
+`QuantumGraph.updateRun()` method is fixed to update dataset ID in references which have their run collection changed.

--- a/python/lsst/pipe/base/graph/quantumNode.py
+++ b/python/lsst/pipe/base/graph/quantumNode.py
@@ -151,6 +151,33 @@ class QuantumNode:
             nodeId=simple.nodeId,
         )
 
+    def _replace_quantum(self, quantum: Quantum) -> None:
+        """Replace Quantum instance in this node.
+
+        Parameters
+        ----------
+        quantum : `Quantum`
+            New Quantum instance for this node.
+
+        Raises
+        ------
+        ValueError
+            Raised if the hash of the new quantum is different from the hash of
+            the existing quantum.
+
+        Notes
+        -----
+        This class is immutable and hashable, so this method checks that new
+        quantum does not invalidate its current hash. This method is supposed
+        to used only by `QuantumGraph` class as its implementation detail,
+        so it is made "underscore-protected".
+        """
+        if hash(quantum) != hash(self.quantum):
+            raise ValueError(
+                f"Hash of the new quantum {quantum} does not match hash of existing quantum {self.quantum}"
+            )
+        object.__setattr__(self, "quantum", quantum)
+
 
 _fields_set = {"quantum", "taskLabel", "nodeId"}
 

--- a/tests/test_quantumGraph.py
+++ b/tests/test_quantumGraph.py
@@ -41,7 +41,7 @@ from lsst.pipe.base import (
     TaskDef,
 )
 from lsst.pipe.base.graph.quantumNode import BuildId, QuantumNode
-from lsst.pipe.base.tests.util import check_output_run
+from lsst.pipe.base.tests.util import check_output_run, get_output_refs
 from lsst.utils.introspection import get_full_type_name
 
 METADATA = {"a": [1, 2, 3]}
@@ -561,11 +561,17 @@ class QuantumGraphTestCase(unittest.TestCase):
     def testUpdateRun(self) -> None:
         """Test for QuantumGraph.updateRun method."""
         self.assertEqual(check_output_run(self.qGraph, self.output_run), [])
+        output_refs = get_output_refs(self.qGraph)
+        self.assertGreater(len(output_refs), 0)
         graph_id = self.qGraph.graphID
 
         self.qGraph.updateRun("updated-run")
         self.assertEqual(check_output_run(self.qGraph, "updated-run"), [])
         self.assertEqual(self.qGraph.graphID, graph_id)
+        output_refs2 = get_output_refs(self.qGraph)
+        self.assertEqual(len(output_refs2), len(output_refs))
+        # All output dataset IDs must be updated.
+        self.assertTrue(set(ref.id for ref in output_refs).isdisjoint(set(ref.id for ref in output_refs2)))
 
         # Also update metadata.
         self.qGraph.updateRun("updated-run2", metadata_key="ouput_run")


### PR DESCRIPTION
This commit fixes bug in updateRun which did not update dataset
IDs of the references after changing their run collection.

Depends on lsst/daf_butler#882

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
