### PR TITLE
DM-41116: Few updates fiollowing Butler interface change

### DIFF
--- a/python/lsst/pipe/base/executionButlerBuilder.py
+++ b/python/lsst/pipe/base/executionButlerBuilder.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping
 
 from lsst.daf.butler import Butler, Config, DatasetRef, DatasetType, Registry
+from lsst.daf.butler.direct_butler import DirectButler
 from lsst.daf.butler.registry import ConflictingDefinitionError, MissingDatasetTypeError
 from lsst.daf.butler.repo_relocation import BUTLER_ROOT_TAG
 from lsst.daf.butler.transfers import RepoExportContext
@@ -235,7 +236,9 @@ def _discoverCollections(butler: Butler, collections: Iterable[str]) -> set[str]
     return collections
 
 
-def _export(butler: Butler, collections: Iterable[str] | None, inserts: DataSetTypeRefMap) -> io.StringIO:
+def _export(
+    butler: DirectButler, collections: Iterable[str] | None, inserts: DataSetTypeRefMap
+) -> io.StringIO:
     # This exports relevant dimension records and collections using daf butler
     # objects, however it reaches in deep and does not use the public methods
     # so that it can export it to a string buffer and skip disk access.  This
@@ -270,7 +273,7 @@ def _export(butler: Butler, collections: Iterable[str] | None, inserts: DataSetT
 
 
 def _setupNewButler(
-    butler: Butler,
+    butler: DirectButler,
     outputLocation: ResourcePath,
     dirExists: bool,
     datastoreRoot: ResourcePath | None = None,
@@ -337,7 +340,7 @@ def _setupNewButler(
     )
 
     # Return a newly created butler
-    return Butler(config, writeable=True)
+    return Butler.from_config(config, writeable=True)
 
 
 def _import(
@@ -374,7 +377,7 @@ def _import(
 
 
 def buildExecutionButler(
-    butler: Butler,
+    butler: DirectButler,
     graph: QuantumGraph,
     outputLocation: ResourcePathExpression,
     run: str | None,
@@ -398,8 +401,8 @@ def buildExecutionButler(
     Parameters
     ----------
     butler : `lsst.daf.butler.Butler`
-        This is the existing `~lsst.daf.butler.Butler` instance from which
-        existing datasets will be exported. This should be the
+        This is the existing `~lsst.daf.butler.Butler` instance from
+        which existing datasets will be exported. This should be the
         `~lsst.daf.butler.Butler` which was used to create any `QuantumGraphs`
         that will be converted with this object.
     graph : `QuantumGraph`

--- a/python/lsst/pipe/base/pipeline_graph/__main__.py
+++ b/python/lsst/pipe/base/pipeline_graph/__main__.py
@@ -77,7 +77,7 @@ def main(argv: Sequence[str]) -> int:
     args = Arguments.from_parsed_args(parser.parse_args(argv))
     pipeline_graph = read_input_pipeline(args.input_pipeline)
     if args.resolve:
-        butler = Butler(args.resolve, writeable=False)
+        butler = Butler.from_config(args.resolve, writeable=False)
         pipeline_graph.resolve(butler.registry)
     if args.save:
         pipeline_graph._write_uri(ResourcePath(args.save))

--- a/python/lsst/pipe/base/script/register_instrument.py
+++ b/python/lsst/pipe/base/script/register_instrument.py
@@ -53,7 +53,7 @@ def register_instrument(repo: str, instrument: list[str], update: bool = False) 
         Raised iff the instrument is not a subclass of
         `lsst.pipe.base.Instrument`.
     """
-    butler = Butler(repo, writeable=True)
+    butler = Butler.from_config(repo, writeable=True)
     for string in instrument:
         instrument_instance = Instrument.from_string(string, butler.registry)
         instrument_instance.register(butler.registry, update=update)

--- a/python/lsst/pipe/base/script/transfer_from_graph.py
+++ b/python/lsst/pipe/base/script/transfer_from_graph.py
@@ -98,7 +98,7 @@ def transfer_from_graph(
         dataset_types=dataset_types,
     )
 
-    dest_butler = Butler(dest, writeable=True)
+    dest_butler = Butler.from_config(dest, writeable=True)
 
     transferred = dest_butler.transfer_from(
         qbb,

--- a/python/lsst/pipe/base/tests/simpleQGraph.py
+++ b/python/lsst/pipe/base/tests/simpleQGraph.py
@@ -276,7 +276,7 @@ def makeSimpleButler(
         butler_config["registry", "db"] = f"sqlite:///{root_path.ospath}/gen3.sqlite"
         butler_config["datastore", "cls"] = "lsst.daf.butler.datastores.fileDatastore.FileDatastore"
     repo = butlerTests.makeTestRepo(str(root_path), {}, config=butler_config)
-    butler = Butler(butler=repo, run=run)
+    butler = Butler.from_config(butler=repo, run=run)
     return butler
 
 

--- a/tests/test_executionButler.py
+++ b/tests/test_executionButler.py
@@ -32,6 +32,7 @@ import unittest
 
 import lsst.utils.tests
 from lsst.daf.butler import Butler
+from lsst.daf.butler.direct_butler import DirectButler
 from lsst.pipe.base.executionButlerBuilder import buildExecutionButler
 from lsst.pipe.base.tests import simpleQGraph
 from lsst.utils.tests import temporaryDirectory
@@ -46,6 +47,7 @@ class ExecutionTestCase(unittest.TestCase):
         """Test buildExecutionButler with default butler config."""
         with temporaryDirectory() as root:
             butler, qgraph = simpleQGraph.makeSimpleQGraph(root=root, inMemory=False)
+            assert isinstance(butler, DirectButler), "Expect DirectButler in tests"
             buildExecutionButler(butler, qgraph, os.path.join(root, "exec_butler"), butler.run)
 
     def test_obscore(self) -> None:
@@ -57,7 +59,8 @@ class ExecutionTestCase(unittest.TestCase):
 
             # Need a fresh butler instance to make sure it reads config from
             # butler.yaml, which does not have full obscore config.
-            butler = Butler(root, run=butler.run)
+            butler = Butler.from_config(root, run=butler.run)
+            assert isinstance(butler, DirectButler), "Expect DirectButler in tests"
             buildExecutionButler(butler, qgraph, os.path.join(root, "exec_butler"), butler.run)
 
 


### PR DESCRIPTION
Butler is now an abstract class, and preferred way to instantiate butlers
is `Butler.from_config`. Execution butler requires a `DirectButler` instance,
updated type annotations to reflect that.

## Checklist

- [X] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
