### PR TITLE
DM-41846: Use the test ID as the unique component of the test run collection

### DIFF
--- a/tests/test_testUtils.py
+++ b/tests/test_testUtils.py
@@ -247,7 +247,7 @@ class PipelineTaskTestSuite(lsst.utils.tests.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.butler = butlerTests.makeTestCollection(self.repo)
+        self.butler = butlerTests.makeTestCollection(self.repo, uniqueId=self.id())
 
     def _makeVisitTestData(self, dataId):
         """Create dummy datasets suitable for VisitTask.


### PR DESCRIPTION
This is a reasonable thing to do in general, but is important when using pytest-randomly because when using that plugin without the --randomly-dont-reset-seed flag, the seed is forced to the global value before every test is run. This leads to makeTestCollection returning the same random integer for every test and the runs clash in the shared repo.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
