### PR TITLE
DM-41853: Handle MetaClass behavioral changes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/doc/changes/DM-41853.bugfix.md
+++ b/doc/changes/DM-41853.bugfix.md
@@ -1,0 +1,1 @@
+Fix bug in MetaClass compatibility between python versions for DatasetQueryConstraints

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 keywords=["lsst"]

--- a/python/lsst/pipe/base/_datasetQueryConstraints.py
+++ b/python/lsst/pipe/base/_datasetQueryConstraints.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 __all__ = ("DatasetQueryConstraintVariant",)
 
+import sys
 import warnings
 from collections.abc import Iterable, Iterator
 from typing import Protocol
@@ -101,7 +102,16 @@ class DatasetQueryConstraintVariant(Iterable, Protocol):
             return cls.LIST(members)
 
 
-class _ALLMETA(DatasetQueryConstraintVariant, type(Protocol)):
+if sys.version_info.minor < 12:
+    MetaMeta = type
+else:
+
+    class MetaMeta(type(Protocol)):
+        def __init__(cls, *args, **kwargs):
+            return super().__init__(cls, *args, **kwargs)
+
+
+class _ALLMETA(DatasetQueryConstraintVariant, type(Protocol), metaclass=MetaMeta):
     def __iter__(self) -> Iterator:  # noqa: N804
         raise NotImplementedError("This variant cannot be iterated")
 
@@ -111,7 +121,7 @@ class _ALL(metaclass=_ALLMETA):
         return cls
 
 
-class _OFFMETA(DatasetQueryConstraintVariant, type(Protocol)):
+class _OFFMETA(DatasetQueryConstraintVariant, type(Protocol), metaclass=MetaMeta):
     def __iter__(self) -> Iterator:  # noqa: N804
         raise NotImplementedError("This variant cannot be iterated")
 
@@ -121,7 +131,7 @@ class _OFF(metaclass=_OFFMETA):
         return cls
 
 
-class _LISTMETA(type(Protocol)):
+class _LISTMETA(type(Protocol), metaclass=MetaMeta):
     def __iter__(self):  # noqa: N804
         return iter(tuple())
 


### PR DESCRIPTION
Some meta programming logic used in DatasetQueryConstraints was affected by a change in behavior in newer versions of python. This commit introduces a workaround, as this code may be refactored in the medium to long term.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
