### PR TITLE
DM-41966: Change the default for transferring records from graph to False

### DIFF
--- a/python/lsst/pipe/base/cli/cmd/commands.py
+++ b/python/lsst/pipe/base/cli/cmd/commands.py
@@ -53,7 +53,7 @@ def register_instrument(*args: Any, **kwargs: Any) -> None:
 @click.argument("graph", required=True)
 @click.argument("dest", required=True)
 @register_dataset_types_option()
-@transfer_dimensions_option()
+@transfer_dimensions_option(default=False)
 @update_output_chain_option()
 @options_file_option()
 def transfer_from_graph(**kwargs: Any) -> None:


### PR DESCRIPTION
In all our use cases the graph will have been created from the butler we are transferring back into and the additional record queries are purely overhead.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
