### PR TITLE
DM-42301: Make calibration-lookup logic less restrictive.

### DIFF
--- a/doc/changes/DM-42301.bugfix.md
+++ b/doc/changes/DM-42301.bugfix.md
@@ -1,0 +1,1 @@
+Fix a QG generation bug involving unusual combinations of dimensions and calibration datasets.


### PR DESCRIPTION
Logic in the prerequisite finders that was expecting a regular calibration lookup was not correctly handling cases where the task did not have temporal dimensions even though the dataset was a calibration; it was raising exceptions even though falling through to findDataset or queryDatasets calls would have worked just fine.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
