### PR TITLE
DM-42306: Support --dry-run flag in transfer-from-graph

### DIFF
--- a/doc/changes/DM-42306.feature.rst
+++ b/doc/changes/DM-42306.feature.rst
@@ -1,0 +1,1 @@
+The ``butler transfer-from-graph`` command now supports a ``--dry-run`` option to allow the transfer to run without updating the target butler.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ zip-safe = true
 license-files = ["COPYRIGHT", "LICENSE", "bsd_license.txt", "gpl-v3.0.txt"]
 
 [tool.setuptools.package-data]
-"lsst.pipe.base" = ["py.typed"]
+"lsst.pipe.base" = ["py.typed", "cli/resources.yaml"]
 
 [tool.setuptools.dynamic]
 version = { attr = "lsst_versions.get_lsst_version" }

--- a/python/lsst/pipe/base/cli/cmd/commands.py
+++ b/python/lsst/pipe/base/cli/cmd/commands.py
@@ -55,6 +55,9 @@ def register_instrument(*args: Any, **kwargs: Any) -> None:
 @register_dataset_types_option()
 @transfer_dimensions_option(default=False)
 @update_output_chain_option()
+@click.option(
+    "--dry-run", is_flag=True, default=False, help="Run the transfer but do not update the destination butler"
+)
 @options_file_option()
 def transfer_from_graph(**kwargs: Any) -> None:
     """Transfer datasets from a quantum graph to a destination butler.

--- a/python/lsst/pipe/base/script/transfer_from_graph.py
+++ b/python/lsst/pipe/base/script/transfer_from_graph.py
@@ -38,6 +38,7 @@ def transfer_from_graph(
     register_dataset_types: bool,
     transfer_dimensions: bool,
     update_output_chain: bool,
+    dry_run: bool,
 ) -> int:
     """Transfer output datasets from quantum graph to dest.
 
@@ -57,6 +58,8 @@ def transfer_from_graph(
         If quantum graph metadata includes output run name and output
         collection which is a chain, update the chain definition to include run
         name as a the first collection in the chain.
+    dry_run : `bool`
+        Run the transfer without updating the destination butler.
 
     Returns
     -------
@@ -106,6 +109,7 @@ def transfer_from_graph(
         transfer="auto",
         register_dataset_types=register_dataset_types,
         transfer_dimensions=transfer_dimensions,
+        dry_run=dry_run,
     )
     count = len(transferred)
 


### PR DESCRIPTION
Depends on lsst/daf_butler#942

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
