### PR TITLE
Add Input connection with deferred binding

### DIFF
--- a/python/lsst/pipe/base/connectionTypes.py
+++ b/python/lsst/pipe/base/connectionTypes.py
@@ -298,6 +298,13 @@ class Input(BaseInput):
         spatial overlaps.  This option has no effect when the connection is not
         an overall input of the pipeline (or subset thereof) for which a graph
         is being created, and it never affects the ordering of quanta.
+    deferBinding : `bool`, optional
+        If `True`, the dataset will not be automatically included in
+        the pipeline graph, ``deferGraphConstraint`` is implied.
+        The custom QuantumGraphBuilder is required to bind it and add a
+        corresponding edge to the pipeline graph.
+        This option allows to have the same dataset type as both
+        input and output of a quantum.
 
     Raises
     ------
@@ -309,6 +316,8 @@ class Input(BaseInput):
     """
 
     deferGraphConstraint: bool = False
+
+    deferBinding: bool = False
 
     _connection_type_set: ClassVar[str] = "inputs"
 

--- a/python/lsst/pipe/base/pipeline_graph/_tasks.py
+++ b/python/lsst/pipe/base/pipeline_graph/_tasks.py
@@ -527,6 +527,7 @@ class TaskNode:
         inputs = {
             name: ReadEdge._from_connection_map(key, name, data.connection_map)
             for name in data.connections.inputs
+            if not getattr(data.connections, name).deferBinding
         }
         init_outputs = {
             name: WriteEdge._from_connection_map(init_key, name, data.connection_map)


### PR DESCRIPTION
These are minimal changes to make an input connection with deferred binding, which would allow us to have an input connection with the same dataset type as an output. (The input would have a different dataset reference than the output.)

This is the first step in creating a `Quantum Graph`, which would process images with persistence. In this use case, the images must be processed in order, each `QuantumNode` takes prior persistence state and produces its own.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
