### PR TITLE
DM-43960: Make PipelineStepTester more flexible

### DIFF
--- a/doc/changes/DM-43960.misc.rst
+++ b/doc/changes/DM-43960.misc.rst
@@ -1,0 +1,2 @@
+Add an optional parameter to PipelineStepTester that lets configs be tweaked before testing.
+This is needed for AP pipelines, whose APDB config cannot be defaulted, and is not intended for wide adoption.

--- a/python/lsst/pipe/base/tests/pipelineStepTester.py
+++ b/python/lsst/pipe/base/tests/pipelineStepTester.py
@@ -157,7 +157,10 @@ class PipelineStepTester:
                 butler.registry.registerDatasetType(node.dataset_type)
 
         if not pure_inputs.keys() <= self.expected_inputs:
-            missing = [f"{k} ({pure_inputs[k]})" for k in pure_inputs.keys() - self.expected_inputs]
+            missing = []
+            for type_name in pure_inputs.keys() - self.expected_inputs:
+                suffix = pure_inputs[type_name]
+                missing.append(type_name + (f" ({suffix})" if suffix else ""))
             raise AssertionError(f"Got unexpected pure_inputs: {missing}")
 
         if not all_outputs.keys() >= self.expected_outputs:


### PR DESCRIPTION
This PR adds an optional config patcher to `PipelineStepTester`, making it possible to run it on `ApPipe` and `ApPipeWithFakes`.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
