### PR TITLE
DM-43020: Implement region and time extraction for preload

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,5 +1,5 @@
 2016-2021 Association of Universities for Research in Astronomy, Inc. (AURA)
-2015-2018, 2020-2021 University of Washington
+2015-2018, 2020-2021, 2024 University of Washington
 2015-2021 The Trustees of Princeton University
 2017-2021 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
 2016 University of Illinois Board of Trustees

--- a/doc/changes/DM-43020.misc.rst
+++ b/doc/changes/DM-43020.misc.rst
@@ -1,0 +1,2 @@
+Add ``pipe.base.utils.RegionTimeInfo``, a container for serializing pairs of sky region and timespan.
+It's intended for several specific applications when running the AP pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ convention = "numpy"
 checks = [
     "all",  # All except the rules listed below.
     "SA01",  # See Also section.
+    "SA04",  # We don't use descriptions with See Also.
     "EX01",  # Example section.
     "SS06",  # Summary can go into second line.
     "GL01",  # Summary text can start on same line as """

--- a/python/lsst/pipe/base/__init__.py
+++ b/python/lsst/pipe/base/__init__.py
@@ -2,7 +2,7 @@
 # backwards compatibility.
 import warnings
 
-from . import automatic_connection_constants, connectionTypes, pipeline_graph, pipelineIR
+from . import automatic_connection_constants, connectionTypes, pipeline_graph, pipelineIR, utils
 from ._dataset_handle import *
 
 # Symbols from _datasetQueryConstraints are exported from

--- a/python/lsst/pipe/base/_datasetQueryConstraints.py
+++ b/python/lsst/pipe/base/_datasetQueryConstraints.py
@@ -118,6 +118,7 @@ else:
 
     class MetaMeta(type(Protocol)):
         def __init__(cls, *args, **kwargs):
+            # Note: this prepends an *extra* cls to type's argument list
             return super().__init__(cls, *args, **kwargs)
 
 

--- a/python/lsst/pipe/base/utils.py
+++ b/python/lsst/pipe/base/utils.py
@@ -1,0 +1,50 @@
+# This file is part of pipe_base.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This software is dual licensed under the GNU General Public License and also
+# under a 3-clause BSD license. Recipients may choose which of these licenses
+# to use; please see the files gpl-3.0.txt and/or bsd_license.txt,
+# respectively.  If you choose the GPL option then the following text applies
+# (but note that there is still no warranty even if you opt for BSD instead):
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+from __future__ import annotations
+
+__all__ = [
+    "RegionTimeInfo",
+]
+
+
+import lsst.daf.butler
+import pydantic
+
+
+class RegionTimeInfo(pydantic.BaseModel):
+    """A serializable container for a sky region and timespan.
+
+    This container is intended to support translation of observation metadata
+    between Butler dimension records, Butler datasets, and exposure headers.
+    """
+
+    region: lsst.daf.butler.pydantic_utils.SerializableRegion
+    """The sky region stored in this object (`lsst.sphgeom.Region`)."""
+    timespan: lsst.daf.butler.Timespan
+    """The time interval stored in this object (`lsst.daf.butler.Timespan`)."""

--- a/tests/test_pipelineTask.py
+++ b/tests/test_pipelineTask.py
@@ -121,7 +121,7 @@ class PipelineTaskTestCase(unittest.TestCase):
             physical_filter="a",
             band="b",
             instrument="TestInstrument",
-            graph=dstype.dimensions,
+            dimensions=dstype.dimensions,
         )
         run = "test"
         ref = DatasetRef(datasetType=dstype, dataId=dataId, run=run)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+#
+# LSST Data Management System
+# Copyright 2008, 2009, 2010 LSST Corporation.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+#
+
+
+import unittest
+
+import astropy
+import lsst.daf.butler as dafButler
+import lsst.pipe.base as pipeBase
+import lsst.sphgeom as sphgeom
+import lsst.utils.tests
+import pydantic
+
+
+class RegionTimeInfoTestCase(unittest.TestCase):
+    """Unit tests for lsst.pipe.base.utils.RegionTimeInfo.
+
+    Since RegionTimeInfo is a passive container that exists only for
+    serialization convenience, the tests only cover serialization and assume
+    e.g. input validation is handled by the component types.
+    """
+
+    def setUp(self):
+        self.region = sphgeom.Circle(
+            sphgeom.UnitVector3d(sphgeom.Angle.fromDegrees(34.5), sphgeom.Angle.fromDegrees(-42.0)),
+            sphgeom.Angle.fromDegrees(1.0),
+        )
+        self.times = dafButler.Timespan(
+            begin=astropy.time.Time("2013-06-17 13:34:45.775000", scale="tai", format="iso"),
+            end=astropy.time.Time("2013-06-17 13:35:17.947000", scale="tai", format="iso"),
+        )
+
+    def test_init(self):
+        # Both parameters are mandatory
+        with self.assertRaises(ValueError):
+            pipeBase.utils.RegionTimeInfo()
+        with self.assertRaises(ValueError):
+            pipeBase.utils.RegionTimeInfo(region=self.region)
+        with self.assertRaises(ValueError):
+            pipeBase.utils.RegionTimeInfo(timespan=self.times)
+
+    def test_serialization(self):
+        original = pipeBase.utils.RegionTimeInfo(region=self.region, timespan=self.times)
+        adapter = pydantic.TypeAdapter(pipeBase.utils.RegionTimeInfo)
+
+        roundtripped = adapter.validate_json(adapter.dump_json(original))
+        self.assertEqual(roundtripped, original)
+
+
+class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
+    """Run file leak tests."""
+
+
+def setup_module(module):
+    """Configure pytest."""
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This PR adds a `RegionTimeInfo` class for bundling regions and timespans into one Butler dataset. It also fixes some pre-existing warnings.

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
