### PR TITLE
DM-44583: support manual config outputs in mocking system

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -25,25 +25,21 @@ jobs:
       - name: Install graphviz
         run: sudo apt-get install graphviz
 
-      - name: Set the VIRTUAL_ENV variable for uv to work
-        run: |
-          echo "VIRTUAL_ENV=${Python_ROOT_DIR}" >> $GITHUB_ENV
-
       - name: Update pip/wheel infrastructure and install uv
         run: |
           python -m pip install --upgrade pip
           pip install uv
-          uv pip install wheel
+          uv pip install --system wheel
 
       - name: Install documenteer
-        run: uv pip install 'documenteer[pipelines]==0.8.2'
+        run: uv pip install --system 'documenteer[pipelines]==0.8.2'
 
       - name: Install dependencies
         run: |
-          uv pip install -r requirements.txt
+          uv pip install --system -r requirements.txt
 
       - name: Build and install
-        run: uv pip install --no-deps -v -e .
+        run: uv pip install --system --no-deps -v -e .
 
       - name: Build documentation
         working-directory: ./doc

--- a/doc/changes/DM-44583.feature.md
+++ b/doc/changes/DM-44583.feature.md
@@ -1,0 +1,1 @@
+Add mocking support for tasks that write regular datasets with config, log, or metadata storage classes.

--- a/python/lsst/pipe/base/tests/mocks/_storage_class.py
+++ b/python/lsst/pipe/base/tests/mocks/_storage_class.py
@@ -238,6 +238,31 @@ class ConvertedUnmockedDataset(pydantic.BaseModel):
     original_type: str
     """The full Python type of the original unmocked in-memory dataset."""
 
+    # Work around the fact that Sphinx chokes on Pydantic docstring formatting,
+    # when we inherit those docstrings in our public classes.
+    if "sphinx" in sys.modules:
+
+        def copy(self, *args: Any, **kwargs: Any) -> Any:
+            """See `pydantic.BaseModel.copy`."""
+            return super().copy(*args, **kwargs)
+
+        def model_dump(self, *args: Any, **kwargs: Any) -> Any:
+            """See `pydantic.BaseModel.model_dump`."""
+            return super().model_dump(*args, **kwargs)
+
+        def model_dump_json(self, *args: Any, **kwargs: Any) -> Any:
+            """See `pydantic.BaseModel.model_dump_json`."""
+            return super().model_dump(*args, **kwargs)
+
+        def model_copy(self, *args: Any, **kwargs: Any) -> Any:
+            """See `pydantic.BaseModel.model_copy`."""
+            return super().model_copy(*args, **kwargs)
+
+        @classmethod
+        def model_json_schema(cls, *args: Any, **kwargs: Any) -> Any:
+            """See `pydantic.BaseModel.model_json_schema`."""
+            return super().model_json_schema(*args, **kwargs)
+
 
 class MockDatasetQuantum(pydantic.BaseModel):
     """Description of the quantum that produced a mock dataset.


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
