### PR TITLE
DM-26658: (hotfix) Use uri.ospath instead of .path

### DIFF
--- a/python/lsst/pipe/base/formatters/pexConfig.py
+++ b/python/lsst/pipe/base/formatters/pexConfig.py
@@ -51,4 +51,4 @@ class PexConfigFormatter(FormatterV2):
         return Config._fromPython(stream.read().decode())
 
     def write_local_file(self, in_memory_dataset: Any, uri: ResourcePath) -> None:
-        in_memory_dataset.save(uri.path)
+        in_memory_dataset.save(uri.ospath)


### PR DESCRIPTION
This is guaranteed to be a local file and we can not have encoded content.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
