### PR TITLE
DM-44488: support code for error-handling in ctrl_mpexec

### DIFF
--- a/python/lsst/pipe/base/_status.py
+++ b/python/lsst/pipe/base/_status.py
@@ -202,7 +202,7 @@ class AnnotatedPartialOutputsError(RepeatableQuantumError):
                 continue
             item.metadata.set_dict("failure", failure_info)  # type: ignore
 
-        log.exception(
+        log.debug(
             "Task failed with only partial outputs; see exception message for details.",
             exc_info=error,
         )

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -326,7 +326,7 @@ class TaskTestCase(unittest.TestCase):
         task = AddMultTask()
         msg = "something failed!"
         error = ValueError(msg)
-        with self.assertLogs("addMult", level="ERROR") as cm:
+        with self.assertLogs("addMult", level="DEBUG") as cm:
             pipeBase.AnnotatedPartialOutputsError.annotate(error, task, log=task.log)
         self.assertIn(msg, "\n".join(cm.output))
         self.assertEqual(task.metadata["failure"]["message"], msg)
@@ -346,7 +346,7 @@ class TaskTestCase(unittest.TestCase):
         task = AddMultTask()
         msg = "something failed!"
         error = TestError(msg)
-        with self.assertLogs("addMult", level="ERROR") as cm:
+        with self.assertLogs("addMult", level="DEBUG") as cm:
             pipeBase.AnnotatedPartialOutputsError.annotate(error, task, log=task.log)
         self.assertIn(msg, "\n".join(cm.output))
         self.assertEqual(task.metadata["failure"]["message"], msg)


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes` (in ctrl_mpexec)
