### PR TITLE
Clarify usage pattern of AnnotatedPartialOutputsError

### DIFF
--- a/python/lsst/pipe/base/_status.py
+++ b/python/lsst/pipe/base/_status.py
@@ -134,6 +134,10 @@ class AnnotatedPartialOutputsError(RepeatableQuantumError):
     written contain information about their own incompleteness or degraded
     quality.
 
+    Clients should construct this exception by calling `annotate` instead of
+    calling the constructor directly. However, `annotate` does not chain the
+    exception; this must still be done by the client.
+
     This exception should always chain the original error. When the
     executor catches this exception, it will report the original exception. In
     contrast, other exceptions raised from ``runQuantum`` are considered to


### PR DESCRIPTION
This PR tweaks the class docstring for `AnnotatedPartialOutputsError` to emphasize that it does not follow the usual usage pattern for exceptions.

## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`