### PR TITLE
DM-45722: CRITICAL logs on empty quantum graph

### DIFF
--- a/doc/changes/DM-45722.bugfix.md
+++ b/doc/changes/DM-45722.bugfix.md
@@ -1,0 +1,1 @@
+Explanatory logs for "initial data ID query returned no rows" now appear as a single log message instead of one entry per line. This improves display in log aggregators, but there is no change to console behavior.

--- a/doc/changes/DM-45722.misc.md
+++ b/doc/changes/DM-45722.misc.md
@@ -1,0 +1,1 @@
+Explanatory logs for "initial data ID query returned no rows" are now reported at ERROR, not CRITICAL, level.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -18,7 +18,5 @@ The ``<TYPE>`` should be one of:
 
 An example file name would therefore look like ``DM-30291.misc.rst``.
 
-If the change concerns specifically the registry or a datastore the news fragment can be placed in the relevant subdirectory.
-
 You can test how the content will be integrated into the release notes by running ``towncrier --draft --version=V.vv``.
 ``towncrier`` can be installed from PyPI or conda-forge.

--- a/doc/changes/README.rst
+++ b/doc/changes/README.rst
@@ -13,7 +13,6 @@ The ``<TYPE>`` should be one of:
 * ``perf``: A performance enhancement.
 * ``doc``: A documentation improvement.
 * ``removal``: An API removal or deprecation.
-* ``other``: Other Changes and Additions of interest to general users.
 * ``misc``: Changes that are of minor interest.
 
 An example file name would therefore look like ``DM-30291.misc.rst``.

--- a/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
+++ b/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
@@ -507,7 +507,7 @@ class _AllDimensionsQuery:
                 yield result
 
     def log_failure(self, log: LsstLogAdapter) -> None:
-        """Emit a series of CRITICAL-level log message that attempts to explain
+        """Emit a series of ERROR-level log message that attempts to explain
         why the initial data ID query returned no rows.
 
         Parameters
@@ -515,10 +515,10 @@ class _AllDimensionsQuery:
         log : `logging.Logger`
             The logger to use to emit log messages.
         """
-        log.critical("Initial data ID query returned no rows, so QuantumGraph will be empty.")
+        log.error("Initial data ID query returned no rows, so QuantumGraph will be empty.")
         for message in self.common_data_ids.explain_no_results():
-            log.critical(message)
-        log.critical(
+            log.error(message)
+        log.error(
             "To reproduce this query for debugging purposes, run "
             "Registry.queryDataIds with these arguments:"
         )
@@ -527,11 +527,11 @@ class _AllDimensionsQuery:
         # put these args in an easier-to-reconstruct equivalent form
         # so they can read it more easily and copy and paste into
         # a Python terminal.
-        log.critical("  dimensions=%s,", list(self.query_args["dimensions"].names))
-        log.critical("  dataId=%s,", dict(self.query_args["dataId"].required))
+        log.error("  dimensions=%s,", list(self.query_args["dimensions"].names))
+        log.error("  dataId=%s,", dict(self.query_args["dataId"].required))
         if self.query_args["where"]:
-            log.critical("  where=%s,", repr(self.query_args["where"]))
+            log.error("  where=%s,", repr(self.query_args["where"]))
         if "datasets" in self.query_args:
-            log.critical("  datasets=%s,", list(self.query_args["datasets"]))
+            log.error("  datasets=%s,", list(self.query_args["datasets"]))
         if "collections" in self.query_args:
-            log.critical("  collections=%s,", list(self.query_args["collections"]))
+            log.error("  collections=%s,", list(self.query_args["collections"]))

--- a/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
+++ b/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
@@ -36,6 +36,7 @@ __all__ = ("AllDimensionsQuantumGraphBuilder", "DatasetQueryConstraintVariant")
 import dataclasses
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
+from io import StringIO
 from typing import TYPE_CHECKING, Any, final
 
 from lsst.daf.butler.registry import MissingDatasetTypeError
@@ -507,7 +508,7 @@ class _AllDimensionsQuery:
                 yield result
 
     def log_failure(self, log: LsstLogAdapter) -> None:
-        """Emit a series of ERROR-level log message that attempts to explain
+        """Emit an ERROR-level log message that attempts to explain
         why the initial data ID query returned no rows.
 
         Parameters
@@ -515,23 +516,31 @@ class _AllDimensionsQuery:
         log : `logging.Logger`
             The logger to use to emit log messages.
         """
-        log.error("Initial data ID query returned no rows, so QuantumGraph will be empty.")
-        for message in self.common_data_ids.explain_no_results():
-            log.error(message)
-        log.error(
-            "To reproduce this query for debugging purposes, run "
-            "Registry.queryDataIds with these arguments:"
-        )
-        # We could just repr() the queryArgs dict to get something
-        # the user could make sense of, but it's friendlier to
-        # put these args in an easier-to-reconstruct equivalent form
-        # so they can read it more easily and copy and paste into
-        # a Python terminal.
-        log.error("  dimensions=%s,", list(self.query_args["dimensions"].names))
-        log.error("  dataId=%s,", dict(self.query_args["dataId"].required))
-        if self.query_args["where"]:
-            log.error("  where=%s,", repr(self.query_args["where"]))
-        if "datasets" in self.query_args:
-            log.error("  datasets=%s,", list(self.query_args["datasets"]))
-        if "collections" in self.query_args:
-            log.error("  collections=%s,", list(self.query_args["collections"]))
+        # A single multiline log plays better with log aggregators like Loki.
+        buffer = StringIO()
+        try:
+            buffer.write("Initial data ID query returned no rows, so QuantumGraph will be empty.\n")
+            for message in self.common_data_ids.explain_no_results():
+                buffer.write(message)
+                buffer.write("\n")
+            buffer.write(
+                "To reproduce this query for debugging purposes, run "
+                "Registry.queryDataIds with these arguments:\n"
+            )
+            # We could just repr() the queryArgs dict to get something
+            # the user could make sense of, but it's friendlier to
+            # put these args in an easier-to-reconstruct equivalent form
+            # so they can read it more easily and copy and paste into
+            # a Python terminal.
+            buffer.write(f"  dimensions={list(self.query_args['dimensions'].names)},")
+            buffer.write(f"  dataId={dict(self.query_args['dataId'].required)},")
+            if self.query_args["where"]:
+                buffer.write(f"  where={repr(self.query_args['where'])},")
+            if "datasets" in self.query_args:
+                buffer.write(f"  datasets={list(self.query_args['datasets'])},")
+            if "collections" in self.query_args:
+                buffer.write(f"  collections={list(self.query_args['collections'])},")
+        finally:
+            # If an exception was raised, write a partial.
+            log.error(buffer.getvalue())
+            buffer.close()


### PR DESCRIPTION
This PR demotes the explanation of empty quantum graph queries from critical to error (to avoid confusion with truly fatal errors that force termination), and also merges the explanation into a single multiline log (for compatibility with JSON/Loki output).

## Checklist

- [x] ran Jenkins
- [X] added a release note for user-visible changes to `doc/changes`
