### PR TITLE
DM-45722: CRITICAL logs on empty quantum graph

### DIFF
--- a/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
+++ b/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
@@ -532,14 +532,14 @@ class _AllDimensionsQuery:
             # put these args in an easier-to-reconstruct equivalent form
             # so they can read it more easily and copy and paste into
             # a Python terminal.
-            buffer.write(f"  dimensions={list(self.query_args['dimensions'].names)},")
-            buffer.write(f"  dataId={dict(self.query_args['dataId'].required)},")
+            buffer.write(f"  dimensions={list(self.query_args['dimensions'].names)},\n")
+            buffer.write(f"  dataId={dict(self.query_args['dataId'].required)},\n")
             if self.query_args["where"]:
-                buffer.write(f"  where={repr(self.query_args['where'])},")
+                buffer.write(f"  where={repr(self.query_args['where'])},\n")
             if "datasets" in self.query_args:
-                buffer.write(f"  datasets={list(self.query_args['datasets'])},")
+                buffer.write(f"  datasets={list(self.query_args['datasets'])},\n")
             if "collections" in self.query_args:
-                buffer.write(f"  collections={list(self.query_args['collections'])},")
+                buffer.write(f"  collections={list(self.query_args['collections'])},\n")
         finally:
             # If an exception was raised, write a partial.
             log.error(buffer.getvalue())


### PR DESCRIPTION
This PR fixes a display bug introduced in #440, where the reformatted logs were being printed without line breaks at all.

## Checklist

- [x] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
