### PR TITLE
DM-46064: permit storage class conversions of components in PipelineGraph

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           uv pip install -r requirements.txt
           uv pip install moto
+          uv pip install astropy pandas pyarrow
 
       # We have two cores so we can speed up the testing with xdist
       - name: Install pytest packages

--- a/doc/changes/DM-46064.feature.md
+++ b/doc/changes/DM-46064.feature.md
@@ -1,0 +1,1 @@
+Storage class conversions of component dataset types are now supported in pipelines.


### PR DESCRIPTION
This can leave the component DatasetType/Ref seen by the component-reading task with an unexpected parentStorageClass, but we hope the task won't care.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
