### PR TITLE
DM-46968: Add subclass of NoWorkFound that indicates an upstream failure.

### DIFF
--- a/python/lsst/pipe/base/_status.py
+++ b/python/lsst/pipe/base/_status.py
@@ -39,6 +39,7 @@ __all__ = (
     "UnprocessableDataError",
     "AnnotatedPartialOutputsError",
     "NoWorkFound",
+    "UpstreamFailureNoWorkFound",
     "RepeatableQuantumError",
     "AlgorithmError",
     "InvalidQuantumError",
@@ -64,6 +65,13 @@ class NoWorkFound(BaseException):
     This inherits from BaseException because it is used to signal a case that
     we don't consider a real error, even though we often want to use try/except
     logic to trap it.
+    """
+
+
+class UpstreamFailureNoWorkFound(NoWorkFound):
+    """A specialization of `NoWorkFound` that indicates that an upstream task
+    had a problem that was ignored (e.g. to prevent a single-detector failure
+    from bringing down an entire visit).
     """
 
 


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
