### PR TITLE
DM-46948: Add NoWorkFound subclass that indicates an upstream failure

### DIFF
--- a/doc/changes/DM-46948.feature.md
+++ b/doc/changes/DM-46948.feature.md
@@ -1,0 +1,1 @@
+Add `UpstreamFailureNoWorkFound`, an exception that is handled the same way as `NoWorkFound` that indicates that the root problem is probably in an upstream `PipelineTask`.

--- a/python/lsst/pipe/base/_status.py
+++ b/python/lsst/pipe/base/_status.py
@@ -39,6 +39,7 @@ __all__ = (
     "UnprocessableDataError",
     "AnnotatedPartialOutputsError",
     "NoWorkFound",
+    "UpstreamFailureNoWorkFound",
     "RepeatableQuantumError",
     "AlgorithmError",
     "InvalidQuantumError",
@@ -64,6 +65,13 @@ class NoWorkFound(BaseException):
     This inherits from BaseException because it is used to signal a case that
     we don't consider a real error, even though we often want to use try/except
     logic to trap it.
+    """
+
+
+class UpstreamFailureNoWorkFound(NoWorkFound):
+    """A specialization of `NoWorkFound` that indicates that an upstream task
+    had a problem that was ignored (e.g. to prevent a single-detector failure
+    from bringing down an entire visit).
     """
 
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
