### PR TITLE
DM-47505: Don't raise when --dataset-query-constraint args are irrelevant.

### DIFF
--- a/doc/changes/DM-47505.misc.md
+++ b/doc/changes/DM-47505.misc.md
@@ -1,0 +1,1 @@
+QuantumGraph generation will no longer fail when the `--dataset-query-constraint` argument includes a dataset type that is not relevant for one or more pipeline subgraphs.

--- a/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
+++ b/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
@@ -479,10 +479,10 @@ class _AllDimensionsQuery:
             constraint = set(builder.dataset_query_constraint)
             inputs = result.overall_inputs - result.empty_dimensions_dataset_types.keys()
             if remainder := constraint.difference(inputs):
-                raise QuantumGraphBuilderError(
-                    f"{remainder} dataset type(s) specified as a graph constraint, but"
-                    f" do not appear as an overall input to the specified pipeline: {inputs}."
-                    " Note that component datasets are not permitted as constraints."
+                builder.log.debug(
+                    "Ignoring dataset types %s in dataset query constraint that are not inputs to this "
+                    "subgraph, on the assumption that they are relevant for a different subraph.",
+                    remainder,
                 )
             builder.log.debug(f"Constraining graph query using {constraint}")
             result.query_args["datasets"] = constraint


### PR DESCRIPTION
They might be relevant for a different subgraph, and this option needs to be usable on multi-subgraph pipelines where the subgraphs don't have overall inputs in common.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
