### PR TITLE
DM-45545: Disable RUFF100 check to support old and new ruff versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
         name: isort (python)
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.8.0
+    rev: v0.9.3
     hooks:
       - id: ruff
   - repo: https://github.com/numpy/numpydoc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,9 +165,6 @@ select = [
     "W",  # pycodestyle
     "D",  # pydocstyle
 ]
-extend-select = [
-    "RUF100", # Warn about unused noqa
-]
 
 [tool.ruff.lint.pycodestyle]
 max-doc-length = 79


### PR DESCRIPTION
## Checklist

- [ ] ran Jenkins
- [ ] added a release note for user-visible changes to `doc/changes`
