### PR TITLE
DM-46023: make PipelineGraph utilize and check pipeline 'step' definitions.

### DIFF
--- a/doc/changes/DM-46023.feature.md
+++ b/doc/changes/DM-46023.feature.md
@@ -1,0 +1,3 @@
+Finish support for "steps" in pipelines and pipeline graphs.
+
+Steps are an ordered sequence of special pipeline subsets that provide extra information and validation about how pipelines should actually be run.

--- a/doc/lsst.pipe.base/creating-a-pipeline.rst
+++ b/doc/lsst.pipe.base/creating-a-pipeline.rst
@@ -363,9 +363,9 @@ These bits of information allow campaign management / batch production software 
     # the label corresponding to a declared subset, and the dimensions
     # the processing of that subset is expected to take
     - label: step1
-      sharding_dimensions: visit, detector
+      dimensions: visit, detector
     - label: step2
-      sharding_dimensions: tract, patch, skymap
+      dimensions: tract, patch, skymap
 
 
 .. _pipeline_creating_imports:

--- a/python/lsst/pipe/base/pipeline.py
+++ b/python/lsst/pipe/base/pipeline.py
@@ -870,9 +870,12 @@ class Pipeline:
             graph.add_task_subset(
                 label, subset.subset, subset.description if subset.description is not None else ""
             )
-        graph.sort()
+        for step_ir in self._pipelineIR.steps:
+            graph.steps.append(step_ir.label, step_ir.dimensions)
         if registry is not None or visualization_only:
             graph.resolve(registry=registry, visualization_only=visualization_only)
+        else:
+            graph.sort()
         return graph
 
     def _add_task_to_graph(self, label: str, graph: pipeline_graph.PipelineGraph) -> None:

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -547,7 +547,8 @@ class StepIR:
 
     label: str
     """The label associated with this step."""
-    sharding_dimensions: list[str]
+
+    dimensions: list[str]
     """The dimensions to use when sharding this step."""
 
 

--- a/python/lsst/pipe/base/pipelineIR.py
+++ b/python/lsst/pipe/base/pipelineIR.py
@@ -304,7 +304,7 @@ class ConfigIR:
         """Convert to a representation used in yaml serialization."""
         accumulate = {}
         for name in ("python", "dataId", "file"):
-            # if this attribute is thruthy add it to the accumulation
+            # if this attribute is truthy add it to the accumulation
             # dictionary
             if getattr(self, name):
                 accumulate[name] = getattr(self, name)
@@ -834,7 +834,7 @@ class PipelineIR:
                 "Labeled subset names must be unique amongst imports in both labels and  named Subsets"
             )
         # merge in the named subsets for self so this document can override any
-        # that have been delcared
+        # that have been declared
         accumulate_labeled_subsets.update(self.labeled_subsets)
         self.labeled_subsets = accumulate_labeled_subsets
 

--- a/python/lsst/pipe/base/pipeline_graph/__main__.py
+++ b/python/lsst/pipe/base/pipeline_graph/__main__.py
@@ -79,6 +79,8 @@ def main(argv: Sequence[str]) -> int:
     if args.resolve:
         butler = Butler.from_config(args.resolve, writeable=False)
         pipeline_graph.resolve(butler.registry)
+    else:
+        pipeline_graph.resolve(visualization_only=True)
     if args.save:
         pipeline_graph._write_uri(ResourcePath(args.save))
     if args.show:

--- a/python/lsst/pipe/base/pipeline_graph/_edges.py
+++ b/python/lsst/pipe/base/pipeline_graph/_edges.py
@@ -599,7 +599,7 @@ class ReadEdge(Edge):
                 else:
                     raise MissingDatasetTypeError(
                         f"Dataset type {self.parent_dataset_type_name!r} is not registered and not produced "
-                        f"by this pipeline, but it used by task {self.task_label!r}, via component "
+                        f"by this pipeline, but it is used by task {self.task_label!r}, via component "
                         f"{self.component!r}. This pipeline cannot be resolved until the parent dataset "
                         "type is registered."
                     )

--- a/python/lsst/pipe/base/pipeline_graph/_edges.py
+++ b/python/lsst/pipe/base/pipeline_graph/_edges.py
@@ -790,13 +790,17 @@ class WriteEdge(Edge):
             Raised if ``current is not None`` and this edge's definition is not
             compatible with it.
         """
-        dimensions = universe.conform(self.raw_dimensions)
-        dataset_type = DatasetType(
-            self.parent_dataset_type_name,
-            dimensions,
-            storageClass=self.storage_class_name,
-            isCalibration=self.is_calibration,
-        )
+        try:
+            dimensions = universe.conform(self.raw_dimensions)
+            dataset_type = DatasetType(
+                self.parent_dataset_type_name,
+                dimensions,
+                storageClass=self.storage_class_name,
+                isCalibration=self.is_calibration,
+            )
+        except Exception as err:
+            err.add_note(f"In connection {self.connection_name!r} of task {self.task_label!r}.")
+            raise
         if current is not None:
             if not current.is_compatible_with(dataset_type):
                 raise IncompatibleDatasetTypeError(

--- a/python/lsst/pipe/base/pipeline_graph/_exceptions.py
+++ b/python/lsst/pipe/base/pipeline_graph/_exceptions.py
@@ -31,6 +31,7 @@ __all__ = (
     "DuplicateOutputError",
     "EdgesChangedError",
     "IncompatibleDatasetTypeError",
+    "InvalidStepsError",
     "PipelineDataCycleError",
     "PipelineGraphError",
     "PipelineGraphExceptionSafetyError",
@@ -99,3 +100,7 @@ class PipelineGraphExceptionSafetyError(PipelineGraphError):
 
     The originating exception is always chained when this exception is raised.
     """
+
+
+class InvalidStepsError(PipelineGraphError):
+    """Exception raised when the step definitions are invalid."""

--- a/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
+++ b/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
@@ -1930,7 +1930,7 @@ class PipelineGraph:
             have a single ``instance`` attribute that holds a `TaskNode`,
             `TaskInitNode`, `DatasetTypeNode` (or `None`), `ReadEdge`, or
             `WriteEdge` instance.
-        sorted_keys : `Sequence` [ `NodeKey` ] or `None`
+        sorted_keys : `~collections.abc.Sequence` [ `NodeKey` ] or `None`
             Topologically sorted sequence of node keys, or `None` if the graph
             is not sorted.
         task_subsets : `dict` [ `str`, `TaskSubset` ]

--- a/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
+++ b/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
@@ -196,12 +196,18 @@ class PipelineGraph:
 
     @property
     def steps(self) -> StepDefinitions:
-        """An ordered mapping of the labels of task subsets that must be
+        """An ordered iterable of the labels of task subsets that must be
         executed separately.
 
         Steps are intended to be partition of the full pipeline graph - the
         steps together include all tasks, and each task belongs to exactly one
         step - but this is only checked when the graph is resolved.
+
+        The order of the steps is required to be consistent with the graph's
+        topological ordering, and when sorting a graph with steps, that sort
+        order is guaranteed to be consistent with the order of the steps.  But
+        there may be other orderings of the steps that are still valid for
+        execution (e.g. two steps could be runnable in parallel).
         """
         return self._step_definitions
 

--- a/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
+++ b/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
@@ -2247,7 +2247,7 @@ class PipelineGraph:
         # Inputs we've already seen, and the tasks that wanted them:
         inputs_so_far: dict[str, set[str]] = {}
         sort_keys: list[NodeKey] = []
-        keys_sorted: set[NodeKey] = set()
+        keys_already_sorted: set[NodeKey] = set()
         for step_label in self.steps:
             try:
                 task_subset = self.task_subsets[step_label]
@@ -2294,12 +2294,12 @@ class PipelineGraph:
             # Drop step input keys that were already either inputs or outputs
             # of a previous step, since they'll have already been added to
             # sort_keys.
-            new_step_keys.difference_update(keys_sorted)
+            new_step_keys.difference_update(keys_already_sorted)
             # Make the step subgraph, sort it, and extend the overall sort_keys
             # with result.
             step_xgraph = self._xgraph.subgraph(new_step_keys)
             sort_keys.extend(networkx.dag.lexicographical_topological_sort(step_xgraph))
-            keys_sorted.update(new_step_keys)
+            keys_already_sorted.update(new_step_keys)
             for input_name, consuming_tasks in step_inputs.items():
                 inputs_so_far.setdefault(input_name, set()).update(consuming_tasks)
         if not task_labels_so_far.issuperset(self.tasks.keys()):

--- a/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
+++ b/python/lsst/pipe/base/pipeline_graph/_pipeline_graph.py
@@ -214,7 +214,7 @@ class PipelineGraph:
     @steps.setter
     def steps(self, labels: Iterable[str]) -> None:
         # Docstring on getter.
-        self._step_definitions.reset(labels)
+        self._step_definitions.assign(labels)
 
     def get_task_step(self, task_label: str) -> str:
         """Return the step that the given task belongs to.

--- a/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
+++ b/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
@@ -275,7 +275,7 @@ class StepDefinitions:
         with self._unverified_on_success():
             del self._dimensions_by_label[label]
 
-    def reset(self, labels: Iterable[str] = ()) -> None:
+    def assign(self, labels: Iterable[str]) -> None:
         """Set all step definitions to the given labels.
 
         Parameters
@@ -297,6 +297,10 @@ class StepDefinitions:
                 self._dimensions_by_label = {
                     label: self._dimensions_by_label.get(label, frozenset()) for label in labels
                 }
+
+    def clear(self) -> None:
+        """Remove all step definitions."""
+        self.assign(())
 
     def get_dimensions(self, label: str) -> DimensionGroup:
         """Return the dimensions that can be used to split up a step's quanta

--- a/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
+++ b/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
@@ -156,6 +156,13 @@ class TaskSubset(MutableSet[str]):
         with self._step_definitions._unverified_on_success():
             self._members.discard(value)
 
+    @classmethod
+    def _from_iterable(cls, iterable: Iterable[str]) -> set[str]:
+        # This is the hook used by collections.abc.Set when implementing
+        # operators that return new sets.  In this case, we want those to be
+        # regular `set` (builtin) objects, not `TaskSubset` instances.
+        return set(iterable)
+
 
 class StepDefinitions:
     """A collection of the 'steps' defined in a pipeline graph.

--- a/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
+++ b/python/lsst/pipe/base/pipeline_graph/_task_subsets.py
@@ -26,19 +26,22 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import annotations
 
-__all__ = ("TaskSubset",)
+__all__ = ("StepDefinitions", "TaskSubset")
 
-from collections.abc import Iterator, MutableSet
+from collections.abc import Iterable, Iterator, MutableSet
+from contextlib import contextmanager
 
 import networkx
 import networkx.algorithms.boundary
 
-from ._exceptions import PipelineGraphError
+from lsst.daf.butler import DimensionGroup, DimensionUniverse
+
+from ._exceptions import InvalidStepsError, PipelineGraphError, UnresolvedGraphError
 from ._nodes import NodeKey, NodeType
 
 
 class TaskSubset(MutableSet[str]):
-    """A specialized set that represents a labeles subset of the tasks in a
+    """A specialized set that represents a labeled subset of the tasks in a
     pipeline graph.
 
     Instances of this class should never be constructed directly; they should
@@ -55,6 +58,8 @@ class TaskSubset(MutableSet[str]):
         Labels of the tasks that are members of this subset.
     description : `str`, optional
         Description string associated with this labeled subset.
+    step_definitions : `StepDefinitions`
+        Information about special 'step' subsets that partition the pipeline.
 
     Notes
     -----
@@ -69,11 +74,13 @@ class TaskSubset(MutableSet[str]):
         label: str,
         members: set[str],
         description: str,
+        step_definitions: StepDefinitions,
     ):
         self._parent_xgraph = parent_xgraph
         self._label = label
         self._members = members
         self._description = description
+        self._step_definitions = step_definitions
 
     @property
     def label(self) -> str:
@@ -90,6 +97,26 @@ class TaskSubset(MutableSet[str]):
         # Docstring in getter.
         self._description = value
 
+    @property
+    def is_step(self) -> bool:
+        """Whether this subset is a step."""
+        return self.label in self._step_definitions
+
+    @property
+    def dimensions(self) -> DimensionGroup:
+        """The dimensions that can be used to split up this subset's quanta
+        into independent groups.
+
+        This is only available if `is_step` is `True` and only if the pipeline
+        graph has been resolved.
+        """
+        return self._step_definitions.get_dimensions(self.label)
+
+    @dimensions.setter
+    def dimensions(self, dimensions: Iterable[str] | DimensionGroup) -> None:
+        # Docstring in getter.
+        self._step_definitions.set_dimensions(self.label, dimensions)
+
     def __repr__(self) -> str:
         return f"{self.label}: {self.description!r}, tasks={{{', '.join(iter(self))}}}"
 
@@ -102,27 +129,221 @@ class TaskSubset(MutableSet[str]):
     def __iter__(self) -> Iterator[str]:
         return iter(self._members)
 
-    def add(self, task_label: str) -> None:
+    def add(self, value: str) -> None:
         """Add a new task to this subset.
 
         Parameters
         ----------
-        task_label : `str`
+        value : `str`
             Label for the task.  Must already be present in the parent pipeline
             graph.
         """
-        key = NodeKey(NodeType.TASK, task_label)
+        key = NodeKey(NodeType.TASK, value)
         if key not in self._parent_xgraph:
-            raise PipelineGraphError(f"{task_label!r} is not a task in the parent pipeline.")
-        self._members.add(key.name)
+            raise PipelineGraphError(f"{value!r} is not a task in the parent pipeline.")
+        with self._step_definitions._unverified_on_success():
+            self._members.add(key.name)
 
-    def discard(self, task_label: str) -> None:
+    def discard(self, value: str) -> None:
         """Remove a task from the subset if it is present.
 
         Parameters
         ----------
-        task_label : `str`
+        value : `str`
             Label for the task.  Must already be present in the parent pipeline
             graph.
         """
-        self._members.discard(task_label)
+        with self._step_definitions._unverified_on_success():
+            self._members.discard(value)
+
+
+class StepDefinitions:
+    """A collection of the 'steps' defined in a pipeline graph.
+
+    Steps are special task subsets that must be executed separately.  They may
+    also be associated with "sharding dimensions", which are the dimensions of
+    data IDs that are independent within the step: splitting up a quantum graph
+    along a step's sharding dimensions produces groups that can be safely
+    executed independently.
+
+    Parameters
+    ----------
+    universe : `lsst.daf.butler.DimensionUniverse`, optional
+        Definitions for data dimensions.
+    dimensions_by_label : `dict` [ `str`, `frozenset` [ `str` ] ], optional
+        Sharding dimensions for step subsets, as dictionary with task labels as
+        keys and sets of dimension names as values.
+    verified : `bool`, optional
+        Whether the step definitions have been checked since the last time
+        they or some other relevant aspect of the pipeline graph was changed.
+
+    Notes
+    -----
+    This class only models `collections.abc.Collection` (it is iterable, sized,
+    and can be used with ``in`` tests on label names), but it also supports
+    `append`, `remove`, and `reset` for modifications.
+    """
+
+    def __init__(
+        self,
+        universe: DimensionUniverse | None = None,
+        dimensions_by_label: dict[str, frozenset[str]] | None = None,
+        verified: bool = False,
+    ):
+        self._universe = universe
+        self._dimensions_by_label = dimensions_by_label if dimensions_by_label is not None else {}
+        self._verified = verified
+
+    @property
+    def verified(self) -> bool:
+        """Whether the step definitions have been checked since the last time
+        they or some other relevant aspect of the pipeline graph was changed.
+
+        This is always `True` if there are no step definitions.
+        """
+        # If there are no steps, the step definitions are still verified.
+        return self._verified or not self._dimensions_by_label
+
+    def __contains__(self, label: object) -> bool:
+        return label in self._dimensions_by_label
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._dimensions_by_label)
+
+    def __len__(self) -> int:
+        return len(self._dimensions_by_label)
+
+    def __repr__(self) -> str:
+        return str(list(self._dimensions_by_label))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, StepDefinitions):
+            return self._dimensions_by_label == other._dimensions_by_label
+        return NotImplemented
+
+    def copy(self) -> StepDefinitions:
+        """Create a new instance that does not share any mutable state with
+        this one.
+        """
+        return StepDefinitions(
+            universe=self._universe,
+            dimensions_by_label=self._dimensions_by_label.copy(),
+            verified=self._verified,
+        )
+
+    def append(self, label: str, dimensions: Iterable[str] | DimensionGroup = ()) -> None:
+        """Append a new step.
+
+        Parameters
+        ----------
+        label : `str`
+            Task subset label for the new step.
+        dimensions : `~collections.abc.Iterable` [ `str` ] or \
+                `~lsst.daf.butler.DimensionGroup`, optional
+            Dimensions that can be used to split up the step's quanta
+            into independent groups.
+        """
+        if self._universe is not None:
+            dimensions = self._universe.conform(dimensions)
+        if isinstance(dimensions, DimensionGroup):
+            dimensions = frozenset(dimensions.names)
+        else:
+            dimensions = frozenset(dimensions)
+        with self._unverified_on_success():
+            self._dimensions_by_label[label] = dimensions
+
+    def remove(self, label: str) -> None:
+        """Remove a named step.
+
+        Parameters
+        ----------
+        label : `str`
+            Task subset label to remove from the list of steps.
+
+        Notes
+        -----
+        This does not remove the task subset itself; it just "demotes" it to a
+        non-step subset.
+        """
+        with self._unverified_on_success():
+            del self._dimensions_by_label[label]
+
+    def reset(self, labels: Iterable[str] = ()) -> None:
+        """Set all step definitions to the given labels.
+
+        Parameters
+        ----------
+        labels : `~collections.abc.Iterable` [ `str` ]
+            Subset labels to use as the new steps.
+
+        Notes
+        -----
+        Sharding dimensions are preserved for any label that was previously a
+        step.  If ``labels`` is a `StepDefinitions`` instance, sharding
+        dimensions from that instance will be used.
+        """
+        if isinstance(labels, StepDefinitions):
+            with self._unverified_on_success():
+                self._dimensions_by_label = labels._dimensions_by_label.copy()
+        else:
+            with self._unverified_on_success():
+                self._dimensions_by_label = {
+                    label: self._dimensions_by_label.get(label, frozenset()) for label in labels
+                }
+
+    def get_dimensions(self, label: str) -> DimensionGroup:
+        """Return the dimensions that can be used to split up a step's quanta
+        into independent groups.
+
+        Parameters
+        ----------
+        label : `str`
+            Label for the step.
+
+        Returns
+        -------
+        dimensions : `lsst.daf.butler.DimensionGroup`
+            Dimensions that can be used to split up this step's quanta.
+        """
+        try:
+            raw_dimensions = self._dimensions_by_label[label]
+        except KeyError:
+            raise InvalidStepsError(f"Task subset {label!r} is not a step.") from None
+        if self._universe is not None:
+            return self._universe.conform(raw_dimensions)
+        else:
+            raise UnresolvedGraphError("Step sharding dimensions have not been resolved.")
+
+    def set_dimensions(self, label: str, dimensions: Iterable[str] | DimensionGroup) -> None:
+        """Set the dimensions that can be used to split up a step's quanta
+        into independent groups.
+
+        Parameters
+        ----------
+        label : `str`
+            Label for the step.
+        dimensions : `lsst.daf.butler.DimensionGroup`
+            Dimensions that can be used to split up this step's quanta.
+        """
+        if label not in self._dimensions_by_label:
+            raise PipelineGraphError(f"Subset {label!r} is not a step.")
+        if self._universe is not None:
+            dimensions = self._universe.conform(dimensions)
+        if isinstance(dimensions, DimensionGroup):
+            dimensions = frozenset(dimensions.names)
+        else:
+            dimensions = frozenset(dimensions)
+        with self._unverified_on_success():
+            self._dimensions_by_label[label] = dimensions
+
+    @contextmanager
+    def _unverified_on_success(self) -> Iterator[None]:
+        """Return the a context manager that marks the step definitions as
+        unverified if it is exited without an exception.
+
+        This should be used only for exception-safe modifications for which an
+        exception means no changes were made (and hence the verified state can
+        remain unchanged as well).
+        """
+        yield
+        self._verified = False

--- a/python/lsst/pipe/base/pipeline_graph/io.py
+++ b/python/lsst/pipe/base/pipeline_graph/io.py
@@ -588,7 +588,7 @@ class SerializedDatasetTypeNode(pydantic.BaseModel):
 class SerializedTaskSubset(pydantic.BaseModel):
     """Struct used to represent a serialized `TaskSubset` in a `PipelineGraph`.
 
-    The subsetlabel is serialized by the context in which a
+    The subset label is serialized by the context in which a
     `SerializedDatasetTypeNode` appears (e.g. the keys of the nested dictionary
     in which it serves as the value type).
     """
@@ -607,26 +607,23 @@ class SerializedTaskSubset(pydantic.BaseModel):
     """
 
     @classmethod
-    def serialize(cls, target: TaskSubset, steps: StepDefinitions) -> SerializedTaskSubset:
+    def serialize(cls, target: TaskSubset) -> SerializedTaskSubset:
         """Transform a `TaskSubset` into a `SerializedTaskSubset`.
 
         Parameters
         ----------
         target : `TaskSubset`
             Object to serialize.
-        steps : `StepDefinitions`
-            Step definitions for the pipeline graph.
 
         Returns
         -------
         `SerializedTaskSubset`
             Object in serializable form.
         """
-        dimensions = list(steps._dimensions_by_label.get(target.label, ()))
-        dimensions.sort()
+        dimensions = sorted(target._step_definitions._dimensions_by_label.get(target.label, ()))
         return cls.model_construct(
             description=target._description,
-            tasks=list(sorted(target)),
+            tasks=sorted(target),
             dimensions=dimensions,
         )
 
@@ -640,7 +637,7 @@ class SerializedTaskSubset(pydantic.BaseModel):
         label : `str`
             Subset label.
         xgraph : `networkx.MultiDiGraph`
-            The under-unconstruction networkx graph that backs the pipeline
+            The under-construction networkx graph that backs the pipeline
             graph.
         steps : `StepDefinitions`
             Step definitions for the pipeline graph.  Modified in-place to
@@ -712,8 +709,7 @@ class SerializedPipelineGraph(pydantic.BaseModel):
                 for name in target.dataset_types
             },
             task_subsets={
-                label: SerializedTaskSubset.serialize(subset, target.steps)
-                for label, subset in target.task_subsets.items()
+                label: SerializedTaskSubset.serialize(subset) for label, subset in target.task_subsets.items()
             },
             step_labels=list(target.steps),
             steps_verified=target.steps.verified,

--- a/python/lsst/pipe/base/pipeline_graph/io.py
+++ b/python/lsst/pipe/base/pipeline_graph/io.py
@@ -50,7 +50,7 @@ from ._edges import Edge, ReadEdge, WriteEdge
 from ._exceptions import PipelineGraphReadError
 from ._nodes import NodeKey, NodeType
 from ._pipeline_graph import PipelineGraph
-from ._task_subsets import TaskSubset
+from ._task_subsets import StepDefinitions, TaskSubset
 from ._tasks import TaskImportMode, TaskInitNode, TaskNode
 
 _U = TypeVar("_U")
@@ -361,13 +361,15 @@ class SerializedTaskNode(pydantic.BaseModel):
         Returns
         -------
         `SerializedTaskNode`
-            Object tha can be serialized.
+            Object that can be serialized.
         """
+        dimensions = list(target.raw_dimensions)
+        dimensions.sort()
         return cls.model_construct(
             task_class=target.task_class_name,
             init=SerializedTaskInitNode.serialize(target.init),
             config_str=target.get_config_str(),
-            dimensions=list(target.raw_dimensions),
+            dimensions=dimensions,
             prerequisite_inputs={
                 connection_name: SerializedEdge.serialize(edge)
                 for connection_name, edge in sorted(target.prerequisite_inputs.items())
@@ -599,23 +601,38 @@ class SerializedTaskSubset(pydantic.BaseModel):
     determinism.
     """
 
+    dimensions: list[str]
+    """Dimensions that can be used to divide this step's quanta into
+    independent groups.
+    """
+
     @classmethod
-    def serialize(cls, target: TaskSubset) -> SerializedTaskSubset:
+    def serialize(cls, target: TaskSubset, steps: StepDefinitions) -> SerializedTaskSubset:
         """Transform a `TaskSubset` into a `SerializedTaskSubset`.
 
         Parameters
         ----------
         target : `TaskSubset`
             Object to serialize.
+        steps : `StepDefinitions`
+            Step definitions for the pipeline graph.
 
         Returns
         -------
         `SerializedTaskSubset`
             Object in serializable form.
         """
-        return cls.model_construct(description=target._description, tasks=list(sorted(target)))
+        dimensions = list(steps._dimensions_by_label.get(target.label, ()))
+        dimensions.sort()
+        return cls.model_construct(
+            description=target._description,
+            tasks=list(sorted(target)),
+            dimensions=dimensions,
+        )
 
-    def deserialize_task_subset(self, label: str, xgraph: networkx.MultiDiGraph) -> TaskSubset:
+    def deserialize_task_subset(
+        self, label: str, xgraph: networkx.MultiDiGraph, steps: StepDefinitions
+    ) -> TaskSubset:
         """Transform a `SerializedTaskSubset` into a `TaskSubset`.
 
         Parameters
@@ -623,7 +640,11 @@ class SerializedTaskSubset(pydantic.BaseModel):
         label : `str`
             Subset label.
         xgraph : `networkx.MultiDiGraph`
-            <unknown>.
+            The under-unconstruction networkx graph that backs the pipeline
+            graph.
+        steps : `StepDefinitions`
+            Step definitions for the pipeline graph.  Modified in-place to
+            set sharding dimension if this is a step.
 
         Returns
         -------
@@ -631,7 +652,9 @@ class SerializedTaskSubset(pydantic.BaseModel):
             Deserialized object.
         """
         members = set(self.tasks)
-        return TaskSubset(xgraph, label, members, self.description)
+        if label in steps:
+            steps.set_dimensions(label, self.dimensions)
+        return TaskSubset(xgraph, label, members, self.description, steps)
 
 
 class SerializedPipelineGraph(pydantic.BaseModel):
@@ -659,6 +682,14 @@ class SerializedPipelineGraph(pydantic.BaseModel):
     data_id: dict[str, Any] = pydantic.Field(default_factory=dict)
     """Data ID that constrains all quanta generated from this pipeline."""
 
+    step_labels: list[str] = pydantic.Field(default_factory=list)
+    """List of task subset labels that are steps."""
+
+    steps_verified: bool
+    """Whether the step definitions in this pipeline were checked for
+    consistency with the task and subset definitions.
+    """
+
     @classmethod
     def serialize(cls, target: PipelineGraph) -> SerializedPipelineGraph:
         """Transform a `PipelineGraph` into a `SerializedPipelineGraph`.
@@ -681,8 +712,11 @@ class SerializedPipelineGraph(pydantic.BaseModel):
                 for name in target.dataset_types
             },
             task_subsets={
-                label: SerializedTaskSubset.serialize(subset) for label, subset in target.task_subsets.items()
+                label: SerializedTaskSubset.serialize(subset, target.steps)
+                for label, subset in target.task_subsets.items()
             },
+            step_labels=list(target.steps),
+            steps_verified=target.steps.verified,
             dimensions=target.universe.dimensionConfig.toDict() if target.universe is not None else None,
             data_id=target._raw_data_id,
         )
@@ -784,15 +818,21 @@ class SerializedPipelineGraph(pydantic.BaseModel):
             xgraph.nodes[dataset_type_key]["instance"] = serialized_dataset_type.deserialize(
                 dataset_type_key, xgraph, universe
             )
+        steps = StepDefinitions(
+            universe,
+            dimensions_by_label=dict.fromkeys(self.step_labels, frozenset()),
+            verified=self.steps_verified,
+        )
         result = PipelineGraph.__new__(PipelineGraph)
         result._init_from_args(
             xgraph,
             sorted_keys=[sort_index_map[i] for i in range(len(xgraph))] if sort_index_map else None,
             task_subsets={
-                subset_label: serialized_subset.deserialize_task_subset(subset_label, xgraph)
+                subset_label: serialized_subset.deserialize_task_subset(subset_label, xgraph, steps)
                 for subset_label, serialized_subset in self.task_subsets.items()
             },
             description=self.description,
+            step_definitions=steps,
             universe=universe,
             data_id=self.data_id,
         )

--- a/python/lsst/pipe/base/pipeline_graph/visualization/_formatting.py
+++ b/python/lsst/pipe/base/pipeline_graph/visualization/_formatting.py
@@ -108,7 +108,7 @@ class GetNodeText:
 
     def __call__(self, node: DisplayNodeKey, x: int, style: tuple[str, str]) -> str:
         state = self.xgraph.nodes[node]
-        terms: list[str] = [f"{node}:" if self.options else str(node)]
+        terms: list[str] = [f"{node}:" if self.options.has_details(node.node_type) else str(node)]
         if self.options.dimensions and node.node_type != NodeType.TASK_INIT:
             terms.append(self.format_dimensions(state["dimensions"]))
         if self.options.task_classes and (

--- a/python/lsst/pipe/base/pipeline_graph/visualization/_options.py
+++ b/python/lsst/pipe/base/pipeline_graph/visualization/_options.py
@@ -31,6 +31,8 @@ __all__ = ("NodeAttributeOptions",)
 import dataclasses
 from typing import Literal
 
+from .._nodes import NodeType
+
 
 @dataclasses.dataclass
 class NodeAttributeOptions:
@@ -71,6 +73,25 @@ class NodeAttributeOptions:
 
     def __bool__(self) -> bool:
         return bool(self.dimensions or self.storage_classes or self.task_classes)
+
+    def has_details(self, node_type: NodeType) -> bool:
+        """Check whether there is any information beyond the node name for a
+        node of the given type.
+
+        Parameters
+        ----------
+        node_type : `NodeType`
+            Type of node.
+
+        Returns
+        -------
+        has_details : `bool`
+            Whether a node of this type should display more than its name.
+        """
+        if node_type is NodeType.DATASET_TYPE:
+            return bool(self.dimensions or self.storage_classes)
+        else:
+            return bool(self.dimensions or self.task_classes)
 
     def checked(self, is_resolved: bool) -> NodeAttributeOptions:
         """Check these options against a pipeline graph's resolution status and

--- a/python/lsst/pipe/base/tests/pipelineStepTester.py
+++ b/python/lsst/pipe/base/tests/pipelineStepTester.py
@@ -134,9 +134,10 @@ class PipelineStepTester:
             step_graph = self.load_pipeline_graph(self.filename + suffix)
             step_graph.resolve(butler.registry)
 
-            pure_inputs.update(
-                {name: suffix for name, _ in step_graph.iter_overall_inputs() if name not in all_outputs}
-            )
+            for name, _ in step_graph.iter_overall_inputs():
+                if name not in all_outputs:
+                    tasks = step_graph.consumers_of(name)
+                    pure_inputs[name] = f"{suffix}: {', '.join(task.label for task in tasks)}"
             all_outputs.update(
                 {
                     name: node.dataset_type

--- a/tests/testPipeline5.yaml
+++ b/tests/testPipeline5.yaml
@@ -15,6 +15,6 @@ subsets:
       - modA
 steps:
   - label: sub1
-    sharding_dimensions: ['a', 'b']
+    dimensions: ['a', 'b']
   - label: sub2
-    sharding_dimensions: ['a', 'c']
+    dimensions: ['a', 'c']

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -180,6 +180,27 @@ class PipelineTestCase(unittest.TestCase):
         load = Pipeline.fromString(dump)
         self.assertEqual(pipeline, load)
 
+    def testStepDefinition(self):
+        """Test that step definitions propagate from Pipeline YAML definitions
+        to PipelineGraph.
+        """
+        pipeline_str = textwrap.dedent(
+            """
+            description: Test Pipeline
+            tasks:
+              add: test_pipeline.AddTask
+            subsets:
+              step1: ["add"]
+            steps:
+              - label: "step1"
+                dimensions: []
+        """
+        )
+        # verify that parameters are used in expanding a pipeline
+        pipeline = Pipeline.fromString(pipeline_str)
+        pipeline_graph = pipeline.to_graph()
+        self.assertEqual(list(pipeline_graph.steps), ["step1"])
+
 
 class MyMemoryTestCase(lsst.utils.tests.MemoryTestCase):
     """Run file leak tests."""

--- a/tests/test_pipelineIR.py
+++ b/tests/test_pipelineIR.py
@@ -331,7 +331,7 @@ class PipelineIRTestCase(unittest.TestCase):
             - $TESTDIR/testPipeline5.yaml
         steps:
             - label: sub1
-              sharding_dimensions: ['a', 'e']
+              dimensions: ['a', 'e']
         """
         )
         with self.assertRaises(ValueError):
@@ -346,7 +346,7 @@ class PipelineIRTestCase(unittest.TestCase):
               importSteps: false
         steps:
             - label: sub1
-              sharding_dimensions: ['a', 'e']
+              dimensions: ['a', 'e']
         """
         )
         PipelineIR.from_string(pipeline_str)
@@ -380,9 +380,9 @@ class PipelineIRTestCase(unittest.TestCase):
                 - modA
         steps:
             - label: sub1
-              sharding_dimensions: ['a', 'b']
+              dimensions: ['a', 'b']
             - label: sub2
-              sharding_dimensions: ['a', 'b']
+              dimensions: ['a', 'b']
         """
         )
         pipeline = PipelineIR.from_string(pipeline_str)
@@ -405,9 +405,9 @@ class PipelineIRTestCase(unittest.TestCase):
                 - modA
         steps:
             - label: sub1
-              sharding_dimensions: ['a', 'b']
+              dimensions: ['a', 'b']
             - label: sub1
-              sharding_dimensions: ['a', 'b']
+              dimensions: ['a', 'b']
         """
         )
         with self.assertRaises(ValueError):

--- a/tests/test_pipeline_graph.py
+++ b/tests/test_pipeline_graph.py
@@ -25,7 +25,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-"""Tests of things related to the GraphBuilder class."""
+"""Tests of things related to the PipelineGraph class."""
 
 import copy
 import io
@@ -45,6 +45,7 @@ from lsst.pipe.base.pipeline_graph import (
     Edge,
     EdgesChangedError,
     IncompatibleDatasetTypeError,
+    InvalidStepsError,
     NodeKey,
     NodeType,
     PipelineGraph,
@@ -129,7 +130,6 @@ class PipelineGraphTestCase(unittest.TestCase):
     def test_sorting(self) -> None:
         """Test sort methods on PipelineGraph."""
         self.assertFalse(self.graph.has_been_sorted)
-        self.assertFalse(self.graph.is_sorted)
         self.graph.sort()
         self.check_sorted(self.graph)
 
@@ -218,12 +218,17 @@ class PipelineGraphTestCase(unittest.TestCase):
         """Test round-tripping a resolved PipelineGraph through in-memory
         serialization.
         """
+        # Add some steps to make sure those round-trip, too.
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"b"})
+        self.graph.steps = ["step1", "step2"]
         self.graph.resolve(MockRegistry(self.dimensions, {}))
         stream = io.BytesIO()
         self.graph._write_stream(stream)
         stream.seek(0)
         roundtripped = PipelineGraph._read_stream(stream)
         self.check_make_xgraph(roundtripped, resolved=True)
+        self.assertEqual(roundtripped.steps, self.graph.steps)
 
     def test_resolved_file_io(self) -> None:
         """Test round-tripping a resolved PipelineGraph through file
@@ -280,6 +285,176 @@ class PipelineGraphTestCase(unittest.TestCase):
         copy3 = copy.deepcopy(self.graph)
         self.assertIsNot(copy3, self.graph)
         self.check_make_xgraph(copy3, resolved=True)
+
+    def test_valid_steps(self) -> None:
+        """Test step definitions that are valid."""
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"b"})
+        with self.assertRaises(InvalidStepsError):
+            # Can't call this yet; no steps.
+            self.graph.get_task_step("step1")
+        with self.assertRaises(InvalidStepsError):
+            # Can't call this yet either.
+            self.graph.steps.get_dimensions("step1")
+        self.graph.steps = ["step1", "step2"]
+        with self.assertRaises(UnresolvedGraphError):
+            # Still can't call it yet; steps not verified.
+            self.graph.get_task_step("step1")
+        with self.assertRaises(UnresolvedGraphError):
+            # Can't call this yet either.
+            self.graph.steps.get_dimensions("step1")
+        self.assertEqual(list(self.graph.steps), ["step1", "step2"])
+        self.graph.resolve(MockRegistry(self.dimensions, {}))
+        self.assertEqual(str(self.graph.steps), "['step1', 'step2']")
+        self.assertEqual(list(self.graph.steps), ["step1", "step2"])
+        self.assertTrue(self.graph.task_subsets["step1"].is_step)
+        self.assertTrue(self.graph.task_subsets["step2"].is_step)
+        self.assertEqual(self.graph.task_subsets["step1"].dimensions, self.dimensions.empty)
+        self.assertEqual(self.graph.task_subsets["step2"].dimensions, self.dimensions.empty)
+        self.assertEqual(self.graph.get_task_step("a"), "step1")
+        self.assertEqual(self.graph.get_task_step("b"), "step2")
+
+    def test_valid_steps_resolved_graph(self) -> None:
+        """Test step definitions that are valid, adding them to a graph that
+        has already been resolved.
+        """
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"b"})
+        self.graph.resolve(MockRegistry(self.dimensions, {}))
+        # Can't call these yet; no steps.
+        with self.assertRaises(InvalidStepsError):
+            self.graph.get_task_step("a")
+        self.graph.steps = ["step1"]
+        self.graph.steps.append("step2", dimensions=self.dimensions.empty)
+        with self.assertRaises(UnresolvedGraphError):
+            # Still can't call it yet; steps not verified.
+            self.graph.get_task_step("a")
+        self.graph.resolve(MockRegistry(self.dimensions, {}))
+        # After we resolve again everything works.
+        self.assertEqual(list(self.graph.steps), ["step1", "step2"])
+        self.assertEqual(list(self.graph.steps), ["step1", "step2"])
+        self.assertTrue(self.graph.task_subsets["step1"].is_step)
+        self.assertTrue(self.graph.task_subsets["step2"].is_step)
+        self.assertEqual(self.graph.task_subsets["step1"].dimensions, self.dimensions.empty)
+        self.assertEqual(self.graph.task_subsets["step2"].dimensions, self.dimensions.empty)
+        self.assertEqual(self.graph.get_task_step("a"), "step1")
+        self.assertEqual(self.graph.get_task_step("b"), "step2")
+
+    def test_valid_step_exposure_visit_substitution(self) -> None:
+        """Test that step sharding dimensions permit an 'exposure'-based task
+        in a 'visit'-sharded step.
+        """
+        c_config = DynamicTestPipelineTaskConfig()
+        c_config.inputs["input1"] = DynamicConnectionConfig(dataset_type_name="intermediate_1")
+        c_config.outputs["output2"] = DynamicConnectionConfig(
+            dataset_type_name="output_2", dimensions=["exposure", "detector"]
+        )
+        c_config.dimensions = ["exposure"]
+        self.graph.add_task("c", DynamicTestPipelineTask, c_config)
+        self.graph.add_task_subset("step1", {"a", "b"})
+        self.graph.add_task_subset("step2", {"c"})
+        self.graph.steps = ["step1", "step2"]
+        self.graph.task_subsets["step2"].dimensions = {"visit"}
+        self.graph.resolve(MockRegistry(self.dimensions, {}))
+        self.assertEqual(list(self.graph.steps), ["step1", "step2"])
+        self.assertEqual(self.graph.get_task_step("a"), "step1")
+        self.assertEqual(self.graph.get_task_step("b"), "step1")
+        self.assertEqual(self.graph.get_task_step("c"), "step2")
+
+    def test_reset_steps(self) -> None:
+        """Test that assigning steps from one graph to another transfers the
+        sharding dimensions.
+        """
+        new_graph = PipelineGraph()
+        new_graph.add_task_nodes(self.graph.tasks.values(), parent=self.graph)
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"b"})
+        self.graph.steps = ["step1"]
+        # These dimensions are not valid for the task dimensions we have, but
+        # that shouldn't be a problem until we try to resolve them.
+        self.graph.steps.append("step2", dimensions=self.dimensions.conform(["visit"]))
+        new_graph.steps = self.graph.steps
+        with self.assertRaises(InvalidStepsError):
+            new_graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_repeated_task(self) -> None:
+        """Test step definitions that are invalid because a task appears in
+        more than one step.
+        """
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"a", "b"})
+        self.graph.steps = ["step1", "step2"]
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_missing_task(self) -> None:
+        """Test step definitions that are invalid because a task appears in
+        more than one step.
+        """
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.steps = ["step1"]
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_bad_order(self) -> None:
+        """Test step definitions that are invalid because they are inconsistent
+        with the task flow.
+        """
+        self.graph.add_task_subset("step1", {"b"})
+        self.graph.add_task_subset("step2", {"a"})
+        self.graph.steps = ["step1", "step2"]
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_not_a_subset(self) -> None:
+        """Test step definitions that are invalid because they reference a
+        label that is not a task subset.
+        """
+        self.graph.add_task_subset("step1", {"b"})
+        self.graph.add_task_subset("step2", {"a"})
+        self.graph.steps = ["step1", "step2", "step3"]
+        with self.assertRaises(PipelineGraphError):
+            self.graph.steps.get_dimensions("step3")
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_bad_task_dimensions(self) -> None:
+        """Test step definitions that are invalid because the step dimensions
+        (for sharding) are incompatible with task dimensions.
+        """
+        # Resolve up-front so methods below have a DimensionUniverse; this
+        # triggers additional code to check dimensions as early as possible.
+        self.graph.resolve(MockRegistry(self.dimensions, {}))
+        self.graph.add_task_subset("step1", {"a"})
+        self.graph.add_task_subset("step2", {"b"})
+        with self.assertRaises(PipelineGraphError):
+            # Only steps can have dimensions, and this isn't a step yet.
+            self.graph.steps.set_dimensions("step2", {"visit"})
+        self.graph.steps = ["step1", "step2"]
+        self.graph.task_subsets["step2"].dimensions = {"visit"}
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
+
+    def test_invalid_steps_bad_dataset_type_dimensions(self) -> None:
+        """Test step definitions that are invalid because the step dimensions
+        (for sharding) are incompatible with output dataset type dimensions.
+        """
+        # This task includes an output that does not have all of the dimensions
+        # of the task itself, which is probably a malformed task and may be
+        # banned earlier in the future.  At present it is not banned, so the
+        # step validation needs to check for consistency on these output
+        # dataset types as well, and we need to test that.
+        c_config = DynamicTestPipelineTaskConfig()
+        c_config.inputs["input1"] = DynamicConnectionConfig(dataset_type_name="intermediate_1")
+        c_config.outputs["output2"] = DynamicConnectionConfig(dataset_type_name="output_2")
+        c_config.dimensions = ["detector"]
+        self.graph.add_task("c", DynamicTestPipelineTask, c_config)
+        self.graph.add_task_subset("step1", {"a", "b"})
+        self.graph.add_task_subset("step2", {"c"})
+        self.graph.steps = ["step1", "step2"]
+        self.graph.task_subsets["step2"].dimensions = {"detector"}
+        with self.assertRaises(InvalidStepsError):
+            self.graph.resolve(MockRegistry(self.dimensions, {}))
 
     def check_base_accessors(self, graph: PipelineGraph) -> None:
         """Run parameterized tests that check attribute access, iteration, and
@@ -432,7 +607,6 @@ class PipelineGraphTestCase(unittest.TestCase):
         other than sorting.
         """
         self.assertTrue(graph.has_been_sorted)
-        self.assertTrue(graph.is_sorted)
         self.assertEqual(
             [(node_type, name) for node_type, name, _ in graph.iter_nodes()],
             [

--- a/tests/test_pipeline_graph.py
+++ b/tests/test_pipeline_graph.py
@@ -1061,6 +1061,14 @@ class PipelineGraphTestCase(unittest.TestCase):
         # Add the subset back in.
         self.graph.add_task_subset("only_b", {"b"})
         self.assertEqual(self.graph.task_subsets.keys(), {"only_b"})
+        # Add a task to the subset and then remove it.
+        self.graph.task_subsets["only_b"].add("a")
+        self.assertEqual(self.graph.task_subsets["only_b"], {"a", "b"})
+        self.assertEqual(self.graph.task_subsets["only_b"] & {"b"}, {"b"})
+        self.graph.task_subsets["only_b"].remove("a")
+        self.assertEqual(self.graph.task_subsets["only_b"], {"b"})
+        with self.assertRaises(PipelineGraphError):
+            self.graph.task_subsets["only_b"].add("c")
         # Resolve the graph's dataset types and task dimensions.
         self.graph.resolve(MockRegistry(self.dimensions, {}))
         self.assertTrue(self.graph.dataset_types.is_resolved("input_1"))

--- a/tests/test_pipeline_graph.py
+++ b/tests/test_pipeline_graph.py
@@ -1674,6 +1674,30 @@ class PipelineGraphResolveTestCase(unittest.TestCase):
         graph.resolve(MockRegistry(self.dimensions, {}))
         self.assertFalse(graph.dataset_types["d"].is_initial_query_constraint)
 
+    def test_invalid_dimensions(self) -> None:
+        """Test that a connection with an invalid dimensions raises an
+        exception (from butler) with the connection name information included.
+        """
+        self.a_config.outputs["o"] = DynamicConnectionConfig(
+            dataset_type_name="d", dimensions=["frog"], storage_class="StructuredDataList"
+        )
+        graph = self.make_graph()
+        with self.assertRaises(Exception) as error:
+            graph.resolve(MockRegistry(self.dimensions, {}))
+        self.assertEqual(error.exception.__notes__, ["In connection 'o' of task 'a'."])
+
+    def test_invalid_dataset_type_name(self) -> None:
+        """Test that a connection with an invalid dataset type name raises an
+        exception (from butler) with the connection name information included.
+        """
+        self.a_config.outputs["o"] = DynamicConnectionConfig(
+            dataset_type_name=":?", storage_class="StructuredDataList"
+        )
+        graph = self.make_graph()
+        with self.assertRaises(Exception) as error:
+            graph.resolve(MockRegistry(self.dimensions, {}))
+        self.assertEqual(error.exception.__notes__, ["In connection 'o' of task 'a'."])
+
 
 if __name__ == "__main__":
     lsst.utils.tests.init()


### PR DESCRIPTION
Since this was also used to help develop the DM-47320 of drp_pipe, where we're first using these new features, it also includes fixes for a number of small bugs and other papercuts I encountered along the way.

## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`