### PR TITLE
DM-49763: Fix bad empty-QG exception behavior.

### DIFF
--- a/doc/changes/DM-49763.bugfix.md
+++ b/doc/changes/DM-49763.bugfix.md
@@ -1,0 +1,1 @@
+Fixed unintentional exceptions from building an empty `QuantumGraph`.

--- a/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
+++ b/python/lsst/pipe/base/all_dimensions_quantum_graph_builder.py
@@ -130,6 +130,10 @@ class AllDimensionsQuantumGraphBuilder(QuantumGraphBuilder):
         tree = _DimensionGroupTree(subgraph)
         self._query_for_data_ids(tree)
         skeleton = self._make_subgraph_skeleton(tree)
+        if not skeleton.has_any_quanta:
+            # QG is going to be empty; exit early not just for efficiency, but
+            # also so downstream code doesn't have to guard against this case.
+            return skeleton
         self._find_followup_datasets(tree, skeleton)
         dimension_records = self._fetch_most_dimension_records(tree)
         leftovers = self._attach_most_dimension_records(skeleton, dimension_records)

--- a/python/lsst/pipe/base/quantum_graph_skeleton.py
+++ b/python/lsst/pipe/base/quantum_graph_skeleton.py
@@ -194,6 +194,13 @@ class QuantumGraphSkeleton:
         """The total number of edges."""
         return len(self._xgraph.edges)
 
+    @property
+    def has_any_quanta(self) -> bool:
+        """Test whether this graph has any quanta."""
+        for _ in self.iter_all_quanta():
+            return True
+        return False
+
     def has_task(self, task_label: str) -> bool:
         """Test whether the given task is in this skeleton.
 


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
