### PR TITLE
DM-50969: Fix QG logging to reflect what's actually going on.

### DIFF
--- a/doc/changes/DM-50969.bugfix.md
+++ b/doc/changes/DM-50969.bugfix.md
@@ -1,0 +1,1 @@
+Fix quantum graph builder logging to correctly identify when the initial butler query actually starts returning rows.


### PR DESCRIPTION
There can be a substantial delay between submitting the query and starting to iterate over the rows, which was making it hard to tell when the query plan was so bad the DB wasn't even returning anything vs. a large result set being returned.

This also adds verbose-level periodic logging to monitor progress when processing the query result rows.

## Checklist

- [ ] ran Jenkins
- [x] added a release note for user-visible changes to `doc/changes`
