### PR TITLE
DM-51454: Update _DataIdMatchTreeVisitor for new methods in its base class

### DIFF
--- a/python/lsst/pipe/base/tests/mocks/_data_id_match.py
+++ b/python/lsst/pipe/base/tests/mocks/_data_id_match.py
@@ -140,6 +140,22 @@ class _DataIdMatchTreeVisitor(TreeVisitor):
         # docstring is inherited from base class
         raise NotImplementedError()
 
+    def visitCircleNode(self, ra: Any, dec: Any, radius: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+    def visitBoxNode(self, ra: Any, dec: Any, width: Any, height: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+    def visitPolygonNode(self, vertices: list[tuple[Any, Any]], node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
+    def visitRegionNode(self, pos: Any, node: Node) -> Any:
+        # docstring is inherited from base class
+        raise NotImplementedError()
+
     def visitGlobNode(self, expression: Any, pattern: Any, node: Node) -> Any:
         # docstring is inherited from base class
         raise NotImplementedError()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ networkx
 wcwidth
 frozendict
 astropy
+sphinx-prompt == 1.6.0
 lsst-daf-butler @ git+https://github.com/lsst/daf_butler@main
 lsst-utils @ git+https://github.com/lsst/utils@main
 lsst-resources @ git+https://github.com/lsst/resources@main


### PR DESCRIPTION
## Checklist

- [x] ran Jenkins
- [X] ran and inspected `package-docs build`
- [ ] added a release note for user-visible changes to `doc/changes`
