### PR TITLE
DM-51821: Fix transfer-from-graph's update chain

### DIFF
--- a/doc/changes/DM-51821.bugfix.rst
+++ b/doc/changes/DM-51821.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed transfer-from-graph to update chain when asked and output run collection exists even if didn't transfer any datasets.


### PR DESCRIPTION
Fix transfer-from-graph to update chain when asked and output run collection exists even if didn't transfer any datasets.

## Checklist

- [ ] ran Jenkins
- [ ] ran and inspected `package-docs build`
- [ ] added a release note for user-visible changes to `doc/changes`
