### PR TITLE
DM-47563: Switch to public Butler.query_all_datasets()

### DIFF
--- a/python/lsst/pipe/base/tests/mocks/_in_memory_repo.py
+++ b/python/lsst/pipe/base/tests/mocks/_in_memory_repo.py
@@ -330,7 +330,7 @@ class InMemoryRepo:
         during quantum graph generation but absent during execution.
         """
         butler = InMemoryLimitedButler(self.butler.dimensions, self.butler.registry.queryDatasetTypes())
-        for ref in self.butler._query_all_datasets(self.input_chain):
+        for ref in self.butler.query_all_datasets(self.input_chain):
             if is_mock_name(ref.datasetType.storageClass_name):
                 butler.put(
                     MockDataset(


### PR DESCRIPTION
query_all_datasets has moved from private to public in daf_butler, so we need to switch to the public version.

## Checklist

- [x] ran Jenkins
- [ ] ran and inspected `package-docs build`
- [ ] added a release note for user-visible changes to `doc/changes`
