### PR TITLE
Experimental encoding of provenance multiblock files as parquet

### DIFF
--- a/python/convert_multiblock.py
+++ b/python/convert_multiblock.py
@@ -1,0 +1,13 @@
+import click
+
+from lsst.pipe.base.quantum_graph._convert import convert_multiblock_to_parquet
+
+
+@click.command
+@click.argument("path")
+def run(path: str) -> None:
+    convert_multiblock_to_parquet(path, "output.zip")
+
+
+if __name__ == "__main__":
+    run()

--- a/python/lsst/pipe/base/quantum_graph/_convert.py
+++ b/python/lsst/pipe/base/quantum_graph/_convert.py
@@ -1,0 +1,75 @@
+import tempfile
+import zipfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from itertools import batched
+
+import pyarrow as pa
+import zstandard
+from duckdb import DuckDBPyConnection, connect
+
+from ._multiblock import MultiblockReader
+
+
+def convert_multiblock_to_parquet(input_zip_path: str, output_zip_path: str) -> None:
+    with zipfile.ZipFile(input_zip_path, "r") as zf:
+        if (cdict_path := zipfile.Path(zf, "compression_dict")).exists():
+            cdict = zstandard.ZstdCompressionDict(cdict_path.read_bytes())
+        decompressor = zstandard.ZstdDecompressor(cdict)
+        with _initialize_duckdb_connection() as db:
+            for filename in ("quanta", "datasets", "metadata", "logs"):
+                reader = _get_record_batch_reader(filename, zf, decompressor)
+                db.execute(
+                    """
+                COPY (SELECT (data::JSON)::VARIANT as data FROM reader)
+                TO $output_filename (FORMAT 'parquet', COMPRESSION 'zstd')
+                """,
+                    {"output_filename": f"{filename}.parquet"},
+                )
+
+
+@contextmanager
+def _initialize_duckdb_connection(memory_limit: str = "8GB") -> Iterator[DuckDBPyConnection]:
+    """Set up an in-memory DuckDB database, applying a memory limit and using
+    the system tempdir for its working directory.
+    """
+    with (
+        tempfile.TemporaryDirectory(suffix=".duckdb") as tmpdir,
+        connect(
+            config={
+                # DuckDB will use up to 80% of system memory if you don't
+                # explicitly set it.
+                "memory_limit": memory_limit,
+                # DuckDB will use the current working directory if you don't
+                # set it, which is frequently a small quota-limited volume on
+                # USDF.
+                "temp_directory": tmpdir,
+                # For paranoia -- some of the scratch volumes at USDF are
+                # petabyte-sized.
+                "max_temp_directory_size": "128GB",
+            }
+        ) as conn,
+    ):
+        yield conn
+
+
+def _fetch_json_bytes(
+    filename: str, zip: zipfile.ZipFile, decompressor: zstandard.ZstdDecompressor
+) -> Iterator[bytes]:
+    for data in MultiblockReader.read_all_bytes_in_zip(zip, filename, int_size=8, page_size=8 * 1024 * 1024):
+        yield decompressor.decompress(data)
+
+
+def _to_batches(schema: pa.Schema, it: Iterator[bytes]) -> Iterator[pa.RecordBatch]:
+    for batch in batched(it, 1000):
+        array = pa.array(batch)
+        yield pa.RecordBatch.from_arrays([array], schema=schema)
+
+
+def _get_record_batch_reader(
+    filename: str, zip: zipfile.ZipFile, decompressor: zstandard.ZstdDecompressor
+) -> pa.RecordBatchReader:
+    schema = pa.schema([("data", pa.string())])
+    return pa.RecordBatchReader.from_batches(
+        schema, _to_batches(schema, _fetch_json_bytes(filename, zip, decompressor))
+    )

--- a/python/lsst/pipe/base/quantum_graph/_convert.py
+++ b/python/lsst/pipe/base/quantum_graph/_convert.py
@@ -6,7 +6,7 @@ from itertools import batched
 
 import pyarrow as pa
 import zstandard
-from duckdb import DuckDBPyConnection, connect
+from duckdb import ColumnExpression, DuckDBPyConnection, connect
 
 from ._multiblock import MultiblockReader
 
@@ -16,31 +16,29 @@ def convert_multiblock_to_parquet(input_zip_path: str, output_zip_path: str) -> 
         if (cdict_path := zipfile.Path(zf, "compression_dict")).exists():
             cdict = zstandard.ZstdCompressionDict(cdict_path.read_bytes())
         decompressor = zstandard.ZstdDecompressor(cdict)
-        with _initialize_duckdb_connection() as db:
-            for filename, id_field in (
-                ("quanta", "quantum_id"),
-                ("datasets", "dataset_id"),
-                ("metadata", None),
-                ("logs", None),
+        with initialize_duckdb_connection() as db:
+            for filename, id_field, variant_encode, row_group_size in (
+                ("quanta", "quantum_id", True, 122880),
+                ("datasets", "dataset_id", True, 122880),
+                # These don't really work as Parquet -- the individual values
+                # are too large, so we run out of memory easily when writing.
+                # ("metadata", None, False, 2048),
+                # ("logs", None, False, 2048),
             ):
                 reader = _get_record_batch_reader(filename, zf, decompressor)
-                id_column = f"data.{id_field}::UUID AS id," if id_field is not None else ""
-                order_by = "ORDER BY id" if id_field is not None else ""
-                db.execute(
-                    f"""
-                COPY (
-                    SELECT {id_column} data FROM
-                    (SELECT (raw_data::JSON)::VARIANT as data FROM reader)
-                    {order_by}
-                )
-                TO $output_filename (FORMAT 'parquet', COMPRESSION 'zstd')
-                """,
-                    {"output_filename": f"{filename}.parquet"},
-                )
+                sql = db.from_arrow(reader)
+                if variant_encode:
+                    sql = sql.select("(data::JSON)::VARIANT as data")
+                if id_field is not None:
+                    sql = sql.select(
+                        ColumnExpression(f"data.{id_field}").cast("UUID").alias("id"),
+                        "data",
+                    ).order("id")
+                sql.to_parquet(f"{filename}.parquet", compression="zstd", row_group_size=row_group_size)
 
 
 @contextmanager
-def _initialize_duckdb_connection(memory_limit: str = "8GB") -> Iterator[DuckDBPyConnection]:
+def initialize_duckdb_connection(memory_limit: str = "16GB") -> Iterator[DuckDBPyConnection]:
     """Set up an in-memory DuckDB database, applying a memory limit and using
     the system tempdir for its working directory.
     """
@@ -80,7 +78,7 @@ def _to_batches(schema: pa.Schema, it: Iterator[bytes]) -> Iterator[pa.RecordBat
 def _get_record_batch_reader(
     filename: str, zip: zipfile.ZipFile, decompressor: zstandard.ZstdDecompressor
 ) -> pa.RecordBatchReader:
-    schema = pa.schema([("raw_data", pa.string())])
+    schema = pa.schema([("data", pa.string())])
     return pa.RecordBatchReader.from_batches(
         schema, _to_batches(schema, _fetch_json_bytes(filename, zip, decompressor))
     )

--- a/python/lsst/pipe/base/quantum_graph/_convert.py
+++ b/python/lsst/pipe/base/quantum_graph/_convert.py
@@ -17,11 +17,22 @@ def convert_multiblock_to_parquet(input_zip_path: str, output_zip_path: str) -> 
             cdict = zstandard.ZstdCompressionDict(cdict_path.read_bytes())
         decompressor = zstandard.ZstdDecompressor(cdict)
         with _initialize_duckdb_connection() as db:
-            for filename in ("quanta", "datasets", "metadata", "logs"):
+            for filename, id_field in (
+                ("quanta", "quantum_id"),
+                ("datasets", "dataset_id"),
+                ("metadata", None),
+                ("logs", None),
+            ):
                 reader = _get_record_batch_reader(filename, zf, decompressor)
+                id_column = f"data.{id_field}::UUID AS id," if id_field is not None else ""
+                order_by = "ORDER BY id" if id_field is not None else ""
                 db.execute(
-                    """
-                COPY (SELECT (data::JSON)::VARIANT as data FROM reader)
+                    f"""
+                COPY (
+                    SELECT {id_column} data FROM
+                    (SELECT (raw_data::JSON)::VARIANT as data FROM reader)
+                    {order_by}
+                )
                 TO $output_filename (FORMAT 'parquet', COMPRESSION 'zstd')
                 """,
                     {"output_filename": f"{filename}.parquet"},
@@ -69,7 +80,7 @@ def _to_batches(schema: pa.Schema, it: Iterator[bytes]) -> Iterator[pa.RecordBat
 def _get_record_batch_reader(
     filename: str, zip: zipfile.ZipFile, decompressor: zstandard.ZstdDecompressor
 ) -> pa.RecordBatchReader:
-    schema = pa.schema([("data", pa.string())])
+    schema = pa.schema([("raw_data", pa.string())])
     return pa.RecordBatchReader.from_batches(
         schema, _to_batches(schema, _fetch_json_bytes(filename, zip, decompressor))
     )


### PR DESCRIPTION
This is a quick experiment to try writing the provenance multiblock files as parquet instead of a custom binary format.  It's using the new [Variant](https://parquet.apache.org/docs/file-format/types/variantencoding/) column type to work with the JSON data previously stored in the multiblock files.  (These would be better as hand-crafted parquet schemas, but that would take a lot longer to try.)

So far it gives about 3x better compression for the dataset and quanta files.  And the query required by [DM-55322](https://rubinobs.atlassian.net/browse/DM-55322) becomes a one-liner that executes in 15 seconds against ~23 million rows.

Haven't tested random access yet, but the theory is that we will sort the files and just use the row group indexes to do the lookups by UUID.

Doesn't work at all for metadata and logs -- those are large blobs that don't really make sense in parquet.  The files get larger and its hard to get the parquet encoder to not run out of memory when writing them.

## Checklist

- [ ] ran Jenkins
- [ ] ran and inspected `package-docs build`
- [ ] added a release note for user-visible changes to `doc/changes`


[DM-55322]: https://rubinobs.atlassian.net/browse/DM-55322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ