### PR TITLE
DM-55521: Allow regular mutable mappings for metadata failure annnotations.

### DIFF
--- a/python/lsst/pipe/base/_status.py
+++ b/python/lsst/pipe/base/_status.py
@@ -44,6 +44,7 @@ import abc
 import enum
 import logging
 import sys
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 import pydantic
@@ -359,7 +360,7 @@ class GetSetDictMetadataHolder(Protocol):
     """
 
     @property
-    def metadata(self) -> GetSetDictMetadata | None:
+    def metadata(self) -> GetSetDictMetadata | MutableMapping[str, Any] | None:
         pass
 
 
@@ -500,7 +501,8 @@ class AnnotatedPartialOutputsError(RepeatableQuantumError):
             Exception that caused the task to fail.
         *args : `GetSetDictMetadataHolder`
             Objects (e.g. Task, Exposure, SimpleCatalog) to annotate with
-            failure information. They must have a `metadata` property.
+            failure information. They must have a `metadata` property that
+            is a `~collections.abc.MutableMapping`.
         log : `logging.Logger`
             Log to send error message to.
 
@@ -548,7 +550,12 @@ class AnnotatedPartialOutputsError(RepeatableQuantumError):
             # Some outputs may not exist, so we cannot set metadata on them.
             if item is None:
                 continue
-            item.metadata.set_dict("failure", failure_info)  # type: ignore
+            if hasattr(item.metadata, "set_dict"):
+                item.metadata.set_dict("failure", failure_info)  # type: ignore
+            elif isinstance(item.metadata, MutableMapping):
+                item.metadata["failure"] = failure_info
+            else:
+                raise TypeError(f"Invalid metadata type {type(item.metadata).__name__!r}")
 
         log.debug(
             "Task failed with only partial outputs; see exception message for details.",


### PR DESCRIPTION
This is motivated by lsst.images types, which have a regular dict for their metadata instead of a PropertySet-like.

## Checklist

- [x] ran Jenkins
- [x] ran and inspected `package-docs build`
- [ ] added a release note for user-visible changes to `doc/changes`
